### PR TITLE
bind() should not register listener that is already registered

### DIFF
--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -98,7 +98,12 @@ public class WebSocketConnection implements InternalConnection,
 
 	@Override
 	public void bind(ConnectionState state, ConnectionEventListener eventListener) {
-		eventListeners.get(state).add(eventListener);
+		Set<ConnectionEventListener> interestedListeners = new HashSet<ConnectionEventListener>();
+		interestedListeners.addAll(eventListeners.get(state));
+		
+		if( interestedListeners.contains(eventListener) == false ) {
+			eventListeners.get(state).add(eventListener);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
bind() allows to register the same listener more than once causing problems on reconnection. This patch fixes this, by checking if given listener is not registered already.
