### PR TITLE
bind() no longer register listeners that is already registered

### DIFF
--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -98,7 +98,10 @@ public class WebSocketConnection implements InternalConnection,
 
 	@Override
 	public void bind(ConnectionState state, ConnectionEventListener eventListener) {
-		eventListeners.get(state).add(eventListener);
+		if( eventListeners.get(state).contains(eventListener) == false ) {
+			eventListeners.get(state).add(eventListener);
+		}
+
 	}
 
 	@Override


### PR DESCRIPTION
Patched bind() to check if given listener is not already bond to specified event. This solves problems with duplicates on i.e. reconnects
