### PR TITLE
Fix setCluster method in PusherOptions.

### DIFF
--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -110,10 +110,16 @@ public class PusherOptions {
         return this;
     }
 
-    public PusherOptions setCluster(String cluster) {
-        this.host = "ws-" + cluster + "." + PUSHER_DOMAIN;
-        this.wsPort = WS_PORT;
-        this.wssPort = WSS_PORT;
+    /**
+     * Sets host and port information using a single argument.
+     *
+     * @param cluster
+     * @return this, for chaining
+     */
+    public PusherOptions setCluster(Cluster cluster) {
+        this.host = cluster.getHost();
+        this.wsPort = cluster.getWsPort();
+        this.wssPort = cluster.getWssPort();
         return this;
     }
 

--- a/src/test/java/com/pusher/client/PusherOptionsTest.java
+++ b/src/test/java/com/pusher/client/PusherOptionsTest.java
@@ -69,13 +69,13 @@ public class PusherOptionsTest {
 
     @Test
     public void testClusterSetURLIsCorrect() {
-        pusherOptions.setCluster("eu");
+        pusherOptions.setCluster(new Cluster("ws-eu.pusher.com", 80, 443));
         assertEquals(pusherOptions.buildUrl(API_KEY), "wss://ws-eu.pusher.com:443/app/" + API_KEY + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }
 
     @Test
     public void testClusterSetNonSSLURLIsCorrect() {
-        pusherOptions.setCluster("eu").setEncrypted(false);
+        pusherOptions.setCluster(new Cluster("ws-eu.pusher.com", 80, 443)).setEncrypted(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://ws-eu.pusher.com:80/app/" + API_KEY + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }
 


### PR DESCRIPTION
Currently, `setCluster` method in `PusherOptions` class expects a string, when it should expect a `Cluster` instance and set port and host from this object.
