### PR TITLE
Fix java-websocket version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,7 +293,7 @@
         <dependency>
             <groupId>org.java-websocket</groupId>
             <artifactId>java-websocket</artifactId>
-            <version>1.3.1</version>
+            <version>1.3.0</version>
         </dependency>
         <!-- <dependency> Useful for running the included Example apps with logging enabled
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Version 1.3.1 doesn't exist in Maven central anymore (not sure if it got removed or never existed), 1.3.0 is the [latest version](http://search.maven.org/#browse%7C651207691). 