### PR TITLE
fixing javadoc warnings and errors

### DIFF
--- a/src/main/java/com/pusher/client/Pusher.java
+++ b/src/main/java/com/pusher/client/Pusher.java
@@ -22,15 +22,15 @@ import com.pusher.client.util.Factory;
  *
  * <p>
  * By creating a new {@link Pusher} instance and calling {@link
- * Pusher.connect()} a connection to Pusher is established.
+ * Pusher#connect()} a connection to Pusher is established.
  * </p>
  *
  * <p>
  * Subscriptions for data are represented by
  * {@link com.pusher.client.channel.Channel} objects, or subclasses thereof.
- * Subscriptions are created by calling {@link #Pusher.subscribe(String)},
- * {@link #Pusher.subscribePrivate(String)},
- * {@link #Pusher.subscribePresence(String)} or one of the overloads.
+ * Subscriptions are created by calling {@link Pusher#subscribe(String)},
+ * {@link Pusher#subscribePrivate(String)},
+ * {@link Pusher#subscribePresence(String)} or one of the overloads.
  * </p>
  */
 public class Pusher {
@@ -179,8 +179,8 @@ public class Pusher {
      * Disconnect from Pusher.
      *
      * <p>
-     * Calls are ignored if the {@link Pusher.getConnection().getState()} is not
-     * {@link com.pusher.client.connection.ConnectionState.CONNECTED}.
+     * Calls are ignored if the {@link Connection#getState()}, retrieved from {@link Pusher#getConnection}, is not
+     * {@link com.pusher.client.connection.ConnectionState#CONNECTED}.
      * </p>
      */
     public void disconnect() {
@@ -336,7 +336,7 @@ public class Pusher {
     
     /**
      * Get a channel with the given name
-     * @param channelName
+     * @param channelName The name of the channel
      * @return The channel with the given name if it's present, otherwise <code>null</code>
      */
 	public Channel getChannel(String channelName) {

--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -44,10 +44,10 @@ public class PusherOptions {
     }
 
     /**
-     * Sets an encrypted (SSL) connection should be used when connecting to
+     * Sets whether an encrypted (SSL) connection should be used when connecting to
      * Pusher.
      *
-     * @param encrypted
+     * @param encrypted Whether to use an SSL connection
      * @return this, for chaining
      */
     public PusherOptions setEncrypted(final boolean encrypted) {
@@ -85,7 +85,7 @@ public class PusherOptions {
      * convenience method setCluster will set the host and ports correctly from
      * a single argument.
      *
-     * @param host
+     * @param host The host
      * @return this, for chaining
      */
     public PusherOptions setHost(final String host) {
@@ -186,7 +186,7 @@ public class PusherOptions {
      * Construct the URL for the WebSocket connection based on the options
      * previous set on this object and the provided API key
      *
-     * @param apiKey
+     * @param apiKey The API key
      * @return the WebSocket URL
      */
     public String buildUrl(final String apiKey) {

--- a/src/main/java/com/pusher/client/channel/ChannelEventListener.java
+++ b/src/main/java/com/pusher/client/channel/ChannelEventListener.java
@@ -1,26 +1,25 @@
 package com.pusher.client.channel;
 
 /**
- * <p>
  * Client applications should implement this interface if they want to be
  * notified when events are received on a public or private channel.
- * </p>
  *
  * <p>
  * To bind your implementation of this interface to a channel, either:
+ * </p>
  * <ul>
  * <li>Call {@link com.pusher.client.Pusher#subscribe(String)} to subscribe and
  * receive an instance of {@link Channel}.</li>
- * <li>Call {@link Channel#bind(String, ChannelEventListener)} to bind your
+ * <li>Call {@link Channel#bind(String, SubscriptionEventListener)} to bind your
  * listener to a specified event.</li>
  * </ul>
- *
+ * 
+ * <p>
  * Or, call
  * {@link com.pusher.client.Pusher#subscribe(String, ChannelEventListener, String...)}
  * to subscribe to a channel and bind your listener to one or more events at the
  * same time.
  * </p>
- *
  */
 public interface ChannelEventListener extends SubscriptionEventListener {
 

--- a/src/main/java/com/pusher/client/channel/PresenceChannel.java
+++ b/src/main/java/com/pusher/client/channel/PresenceChannel.java
@@ -6,9 +6,8 @@ import java.util.Set;
  * An object that represents a Pusher presence channel. An implementation of
  * this interface is returned when you call
  * {@link com.pusher.client.Pusher#subscribePresence(String)} or
- * {@link com.pusher.client.Pusher#subscribePresence(String, ChannelEventListener, String...)}
+ * {@link com.pusher.client.Pusher#subscribePresence(String, PresenceChannelEventListener, String...)}
  * .
- *
  */
 public interface PresenceChannel extends PrivateChannel {
 

--- a/src/main/java/com/pusher/client/channel/SubscriptionEventListener.java
+++ b/src/main/java/com/pusher/client/channel/SubscriptionEventListener.java
@@ -1,20 +1,20 @@
 package com.pusher.client.channel;
 
 /**
- * <p>
  * Client applications should implement this interface if they want to be
  * notified when events are received on a public or private channel.
- * </p>
  *
  * <p>
  * To bind your implementation of this interface to a channel, either:
+ * </p>
  * <ul>
  * <li>Call {@link com.pusher.client.Pusher#subscribe(String)} to subscribe and
  * receive an instance of {@link Channel}.</li>
- * <li>Call {@link Channel#bind(String, ChannelEventListener)} to bind your
+ * <li>Call {@link Channel#bind(String, SubscriptionEventListener)} to bind your
  * listener to a specified event.</li>
  * </ul>
  *
+ * <p>
  * Or, call
  * {@link com.pusher.client.Pusher#subscribe(String, ChannelEventListener, String...)}
  * to subscribe to a channel and bind your listener to one or more events at the

--- a/src/main/java/com/pusher/client/channel/User.java
+++ b/src/main/java/com/pusher/client/channel/User.java
@@ -16,8 +16,8 @@ public class User {
      * Users are created within the library and represent subscriptions to
      * presence channels.
      *
-     * @param id
-     * @param jsonData
+     * @param id The user id
+     * @param jsonData The user JSON data
      */
     public User(final String id, final String jsonData) {
         this.id = id;
@@ -36,6 +36,8 @@ public class User {
     /**
      * Custom additional information about a user as a String encoding a JSON
      * hash
+     * 
+     * @return The user info as a JSON string
      */
     public String getInfo() {
         return jsonData;
@@ -71,10 +73,11 @@ public class User {
      * info.getNumber() // returns 9
      * </pre>
      *
+     * @param <V> The class of the info
      * @param clazz
      *            the class into which the user info JSON representation should
      *            be parsed.
-     * @return An instance of clazz, populated with the user info
+     * @return V An instance of clazz, populated with the user info
      */
     public <V> V getInfo(final Class<V> clazz) {
         return new Gson().fromJson(jsonData, clazz);

--- a/src/main/java/com/pusher/client/connection/Connection.java
+++ b/src/main/java/com/pusher/client/connection/Connection.java
@@ -7,8 +7,7 @@ package com.pusher.client.connection;
 public interface Connection {
 
     /**
-     * No need to call this via the API. Instead use {@link
-     * com.pusher.client.Pusher.connect()}.
+     * No need to call this via the API. Instead use {@link com.pusher.client.Pusher#connect}.
      */
     void connect();
 

--- a/src/main/java/com/pusher/client/connection/ConnectionEventListener.java
+++ b/src/main/java/com/pusher/client/connection/ConnectionEventListener.java
@@ -1,11 +1,9 @@
 package com.pusher.client.connection;
 
 /**
- * <p>
  * Client applications should implement this interface if they wish to receive
  * notifications when the state of a {@link Connection} changes or an error is
  * thrown.
- * </p>
  *
  * <p>
  * Implementations of this interface can be bound to the connection by calling
@@ -24,11 +22,9 @@ package com.pusher.client.connection;
 public interface ConnectionEventListener {
 
     /**
-     * <p>
      * Callback that is fired whenever the {@link ConnectionState} of the
      * {@link Connection} changes. The state typically changes during connection
      * to Pusher and during disconnection and reconnection.
-     * </p>
      *
      * <p>
      * This callback is only fired if the {@linkplain ConnectionEventListener}
@@ -37,22 +33,18 @@ public interface ConnectionEventListener {
      * either the new state or {@link ConnectionState#ALL}.
      * </p>
      *
-     * @param change
-     *            An object that contains the previous state of the connection
+     * @param change An object that contains the previous state of the connection
      *            and the new state. The new state can be retrieved by calling
      *            {@link ConnectionStateChange#getCurrentState()}.
      */
     void onConnectionStateChange(ConnectionStateChange change);
 
     /**
-     * <p>
      * Callback that indicates either:
-     *
      * <ul>
      * <li>An error message has been received from Pusher, or</li>
      * <li>An error has occurred in the client library.</li>
      * </ul>
-     * </p>
      *
      * <p>
      * All {@linkplain ConnectionEventListener}s that have been registered by

--- a/src/main/java/com/pusher/client/connection/ConnectionStateChange.java
+++ b/src/main/java/com/pusher/client/connection/ConnectionStateChange.java
@@ -12,8 +12,8 @@ public class ConnectionStateChange {
      * Used within the library to create a connection state change. Not be used
      * used as part of the API.
      *
-     * @param previousState
-     * @param currentState
+     * @param previousState The previous connection state
+     * @param currentState The current connection state
      */
     public ConnectionStateChange(final ConnectionState previousState, final ConnectionState currentState) {
 
@@ -31,7 +31,7 @@ public class ConnectionStateChange {
      * The previous connections state. The state the connection has transitioned
      * from.
      *
-     * @return
+     * @return The previous connection state
      */
     public ConnectionState getPreviousState() {
         return previousState;
@@ -41,7 +41,7 @@ public class ConnectionStateChange {
      * The current connection state. The state the connection has transitioned
      * to.
      *
-     * @return
+     * @return The current connection state
      */
     public ConnectionState getCurrentState() {
         return currentState;

--- a/src/main/java/com/pusher/client/util/HttpAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpAuthorizer.java
@@ -56,7 +56,7 @@ public class HttpAuthorizer implements Authorizer {
     /**
      * Set additional headers to be sent as part of the request.
      *
-     * @param headers
+     * @param headers A map of headers
      */
     public void setHeaders(final HashMap<String, String> headers) {
         mHeaders = headers;


### PR DESCRIPTION
@leggetter As promised :smile: 

This PR fixes all javadoc warnings and errors in the 0.4.0-release branch. Most of the errors/warnings were due to:
- `.` rather than `#` was being used to link to methods - see http://www.oracle.com/technetwork/articles/java/index-137868.html
- no `@param` or `@return` tag or tag description
- `<p>...</p>` was being used for the first JavaDoc paragraph - JavaDoc automatically treats the first block as a paragraph so adding the `<p>` tag generates a warning. From http://www.oracle.com/technetwork/articles/java/index-137868.html - `The first sentence of each doc comment should be a summary sentence`
- `<ul>...</ul>` tags were inside of `<p>...</p>` blocks - Not allowed in HTML so JavaDoc fails (http://stackoverflow.com/a/10601411/2634854)