### PR TITLE
Fix binding unbinding concurrent modification

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ target
 
 build
 .gradle
+.idea
+
+*.iml

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -19,7 +19,7 @@ public class ChannelImpl implements InternalChannel {
     private static final String INTERNAL_EVENT_PREFIX = "pusher_internal:";
     protected static final String SUBSCRIPTION_SUCCESS_EVENT = "pusher_internal:subscription_succeeded";
     protected final String name;
-    protected final Map<String, Set<SubscriptionEventListener>> eventNameToListenerMap = new HashMap<String, Set<SubscriptionEventListener>>();
+    private final Map<String, Set<SubscriptionEventListener>> eventNameToListenerMap = new HashMap<String, Set<SubscriptionEventListener>>();
     protected volatile ChannelState state = ChannelState.INITIAL;
     private ChannelEventListener eventListener;
     private final Factory factory;

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -96,10 +96,19 @@ public class ChannelImpl implements InternalChannel {
             updateState(ChannelState.SUBSCRIBED);
         }
         else {
-            final Set<SubscriptionEventListener> listeners = eventNameToListenerMap.get(event);
+            final Set<SubscriptionEventListener> listeners;
+            synchronized (lock) {
+                final Set<SubscriptionEventListener> sharedListeners = eventNameToListenerMap.get(event);
+                if (sharedListeners != null) {
+                    listeners = new HashSet<SubscriptionEventListener>(sharedListeners);
+                }
+                else {
+                    listeners = null;
+                }
+            }
+
             if (listeners != null) {
                 for (final SubscriptionEventListener listener : listeners) {
-
                     final String data = extractDataFrom(message);
 
                     factory.getEventQueue().execute(new Runnable() {

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -22,6 +22,7 @@ public class ChannelImpl implements InternalChannel {
     protected volatile ChannelState state = ChannelState.INITIAL;
     private ChannelEventListener eventListener;
     private final Factory factory;
+    private final Object lock = new Object();
 
     public ChannelImpl(final String channelName, final Factory factory) {
 
@@ -57,7 +58,9 @@ public class ChannelImpl implements InternalChannel {
         Set<SubscriptionEventListener> listeners = eventNameToListenerMap.get(eventName);
         if (listeners == null) {
             listeners = new HashSet<SubscriptionEventListener>();
-            eventNameToListenerMap.put(eventName, listeners);
+            synchronized (lock) {
+              eventNameToListenerMap.put(eventName, listeners);
+            }
         }
 
         listeners.add(listener);
@@ -72,7 +75,9 @@ public class ChannelImpl implements InternalChannel {
         if (listeners != null) {
             listeners.remove(listener);
             if (listeners.isEmpty()) {
-                eventNameToListenerMap.remove(eventName);
+                synchronized (lock) {
+                    eventNameToListenerMap.remove(eventName);
+                }
             }
         }
     }

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -1,5 +1,6 @@
 package com.pusher.client.channel.impl;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -55,15 +56,14 @@ public class ChannelImpl implements InternalChannel {
 
         validateArguments(eventName, listener);
 
-        Set<SubscriptionEventListener> listeners = eventNameToListenerMap.get(eventName);
-        if (listeners == null) {
-            listeners = new HashSet<SubscriptionEventListener>();
-            synchronized (lock) {
-              eventNameToListenerMap.put(eventName, listeners);
+        synchronized (lock) {
+            Set<SubscriptionEventListener> listeners = eventNameToListenerMap.get(eventName);
+            if (listeners == null) {
+                listeners = new HashSet<SubscriptionEventListener>();
+                eventNameToListenerMap.put(eventName, listeners);
             }
+            listeners.add(listener);
         }
-
-        listeners.add(listener);
     }
 
     @Override
@@ -71,11 +71,11 @@ public class ChannelImpl implements InternalChannel {
 
         validateArguments(eventName, listener);
 
-        final Set<SubscriptionEventListener> listeners = eventNameToListenerMap.get(eventName);
-        if (listeners != null) {
-            listeners.remove(listener);
-            if (listeners.isEmpty()) {
-                synchronized (lock) {
+        synchronized (lock) {
+            final Set<SubscriptionEventListener> listeners = eventNameToListenerMap.get(eventName);
+            if (listeners != null) {
+                listeners.remove(listener);
+                if (listeners.isEmpty()) {
                     eventNameToListenerMap.remove(eventName);
                 }
             }


### PR DESCRIPTION
Following on from #71 

Locking around both the `eventNameToListenerMap` and `listeners` HashSet. 