### PR TITLE
add classifiers to tasks that generate archives

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,6 +89,7 @@ task fatJar(type: Jar, dependsOn:configurations.runtime) {
 	baseName = project.name + '-with-dependencies'
 	from { configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) } }
 	with jar
+	classifier = 'jar-with-dependencies'
 }
 assemble.dependsOn fatJar
 
@@ -96,6 +97,7 @@ assemble.dependsOn fatJar
 task sourcesJar(type: Jar, dependsOn: classes) {
 	classifier = 'sources'
 	from sourceSets.main.allSource
+	classifier = 'javadoc'
 }
 assemble.dependsOn sourcesJar
 
@@ -103,6 +105,7 @@ assemble.dependsOn sourcesJar
 task javadocJar(type: Jar, dependsOn: javadoc) {
 	classifier = 'javadoc'
 	from javadoc.destinationDir
+	classifier = 'sources'
 }
 assemble.dependsOn javadocJar
 


### PR DESCRIPTION
Fix for https://github.com/pusher/pusher-websocket-java/issues/80. I've tested this by deploying to a maven repo on my local disk but I can't see anything that would cause it to not work when deploying to an authenticated repo.