### PR TITLE
Use @SerializedName in PresenceChannelImpl

### DIFF
--- a/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
@@ -8,8 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.FieldNamingPolicy;
+import com.google.gson.annotations.SerializedName;
 
 import com.pusher.client.AuthorizationFailureException;
 import com.pusher.client.Authorizer;
@@ -25,9 +24,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
 
     private static final String MEMBER_ADDED_EVENT = "pusher_internal:member_added";
     private static final String MEMBER_REMOVED_EVENT = "pusher_internal:member_removed";
-    private static final Gson GSON = new GsonBuilder()
-            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-            .create();
+    private static final Gson GSON = new Gson();
 
     private final Map<String, User> idToUserMap = Collections.synchronizedMap(new LinkedHashMap<String, User>());
 
@@ -196,17 +193,23 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
     }
 
     private class MemberData {
+        @SerializedName("user_id")
         public String userId;
+        @SerializedName("user_info")
         public Object userInfo;
     }
 
     private class PresenceData {
+        @SerializedName("count")
         public Integer count;
+        @SerializedName("ids")
         public List<String> ids;
+        @SerializedName("hash")
         public Map<String, Object> hash;
     }
 
     private class Presence {
+        @SerializedName("presence")
         public PresenceData presence;
     }
 

--- a/src/test/java/com/pusher/client/channel/impl/PresenceChannelImplTurkeyTest.java
+++ b/src/test/java/com/pusher/client/channel/impl/PresenceChannelImplTurkeyTest.java
@@ -1,0 +1,26 @@
+package com.pusher.client.channel.impl;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.runner.RunWith;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.Locale;
+
+
+@RunWith(MockitoJUnitRunner.class)
+public class PresenceChannelImplTurkeyTest extends PresenceChannelImplTest {
+
+    private static Locale defaultLocale;
+
+    @BeforeClass
+    public static void overrideLocale() {
+        defaultLocale = Locale.getDefault();
+        Locale.setDefault(new Locale("tr", "TR"));
+    }
+
+    @AfterClass
+    public static void resetLocale() {
+        Locale.setDefault(defaultLocale);
+    }
+}


### PR DESCRIPTION
Use @SerializedName annotation instead of a FieldNamingPolicy in PresenceChannelImpl to
resolve an issue when running with the Turkish Locale + gson FieldNamingPolicy (addressed in gson 2.4, https://github.com/google/gson/issues/541)

Reproducible running `./gradlew clean test -Duser.language=tr`

Using @SerializedName is also preferred to better support obfuscation libraries like proguard.

