### PR TITLE
v1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # pusher-java-client changelog
 
+## Version 1.0.1
+
+2015-11-06 hamchapman, jpatel531
+  * Resolves issues where Gson would cast numeric user ids as doubles before converting them to a string, leading to inconsistencies
+
 ## Version 1.0.0
 
 2015-10-7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# pusher-java-client changelog
+# pusher-websocket-java changelog
+
+## Version 1.0.2
+
+2015-11-06 leggetter, siggijons 
+  * Use @SerializedName in PresenceChannelImpl for better serialization support across languages e.g. Turkish
 
 ## Version 1.0.1
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,8 +117,8 @@ githubPages {
 	}
 	commitMessage = "JavaDoc gh-pages for ${version}"
 	credentials {
-		username = getProperty("github.username")
-		password = getProperty("github.password")
+		username = { getProperty("github.username") }
+		password = { getProperty("github.password") }
 	}
 }
 
@@ -138,14 +138,14 @@ uploadArchives { repositories { mavenDeployer {
 	}
 	repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
 		authentication(
-			userName: getProperty("maven.username"),
-			password: getProperty("maven.password")
+			userName: { getProperty("maven.username") },
+			password: { getProperty("maven.password") }
 		)
 	}
 	snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
 		authentication(
-			userName: getProperty("maven.username"),
-			password: getProperty("maven.password")
+			userName: { getProperty("maven.username") },
+			password: { getProperty("maven.password") }
 		)
 	}
 	pom.project {

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ apply plugin: 'org.ajoberstar.github-pages'
 apply plugin: 'signing'
 
 group = "com.pusher"
-version = "1.0.1"
+version = "1.0.2"
 sourceCompatibility = "1.6"
 targetCompatibility = "1.6"
 

--- a/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
@@ -8,8 +8,7 @@ import java.util.Map;
 import java.util.Set;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.FieldNamingPolicy;
+import com.google.gson.annotations.SerializedName;
 
 import com.pusher.client.AuthorizationFailureException;
 import com.pusher.client.Authorizer;
@@ -25,9 +24,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
 
     private static final String MEMBER_ADDED_EVENT = "pusher_internal:member_added";
     private static final String MEMBER_REMOVED_EVENT = "pusher_internal:member_removed";
-    private static final Gson GSON = new GsonBuilder()
-            .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-            .create();
+    private static final Gson GSON = new Gson();
 
     private final Map<String, User> idToUserMap = Collections.synchronizedMap(new LinkedHashMap<String, User>());
 
@@ -196,17 +193,23 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
     }
 
     private class MemberData {
+        @SerializedName("user_id")
         public String userId;
+        @SerializedName("user_info")
         public Object userInfo;
     }
 
     private class PresenceData {
+        @SerializedName("count")
         public Integer count;
+        @SerializedName("ids")
         public List<String> ids;
+        @SerializedName("hash")
         public Map<String, Object> hash;
     }
 
     private class Presence {
+        @SerializedName("presence")
         public PresenceData presence;
     }
 


### PR DESCRIPTION
Takes the work done by @siggijons in #86 and prepares for a v.1.0.2 release.

The test supplied in #86 hasn't been included since it only works in isolation so isn't suitable as a regression test. It was used to manually verify the fix. All existing tests continue to pass so existing functionality remains the same.