### PR TITLE
Create setProxy method in options.

### DIFF
--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -207,6 +207,9 @@ public class PusherOptions {
      * @return this, for chaining
      */
     public PusherOptions setProxy(Proxy proxy){
+        if (proxy == null) {
+          throw new IllegalArgumentException("proxy must not be null (instead use Proxy.NO_PROXY)");
+        }
         this.proxy = proxy;
         return this;
     }

--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -211,6 +211,9 @@ public class PusherOptions {
         return this;
     }
 
+    /**
+     * @returns The proxy to be used when opening a websocket connection to Pusher.
+     */
     public Proxy getProxy() {
         return this.proxy;
     }

--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -35,7 +35,7 @@ public class PusherOptions {
     private long activityTimeout = DEFAULT_ACTIVITY_TIMEOUT;
     private long pongTimeout = DEFAULT_PONG_TIMEOUT;
     private Authorizer authorizer;
-    private Proxy proxy;
+    private Proxy proxy = Proxy.NO_PROXY;
 
     /**
      * Gets whether an encrypted (SSL) connection should be used when connecting
@@ -212,11 +212,7 @@ public class PusherOptions {
     }
 
     public Proxy getProxy() {
-        if (this.proxy == null) {
-            return Proxy.NO_PROXY;
-        } else {
-            return this.proxy;
-        }
+        return this.proxy;
     }
 
     private static String readVersionFromProperties() {
@@ -226,14 +222,14 @@ public class PusherOptions {
             inStream = PusherOptions.class.getResourceAsStream("/pusher.properties");
             p.load(inStream);
             String version = (String)p.get("version");
-            
+
             // If the properties file contents indicates the version is being run
             // from source then replace with a dev indicator. Otherwise the Pusher
             // Socket API will reject the connection.
             if(version.equals(SRC_LIB_DEV_VERSION)) {
             	version = LIB_DEV_VERSION;
             }
-            
+
             if (version != null && version.length() > 0) {
                 return version;
             }

--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -2,6 +2,7 @@ package com.pusher.client;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.Proxy;
 import java.util.Properties;
 
 /**
@@ -34,6 +35,7 @@ public class PusherOptions {
     private long activityTimeout = DEFAULT_ACTIVITY_TIMEOUT;
     private long pongTimeout = DEFAULT_PONG_TIMEOUT;
     private Authorizer authorizer;
+    private Proxy proxy;
 
     /**
      * Gets whether an encrypted (SSL) connection should be used when connecting
@@ -194,6 +196,27 @@ public class PusherOptions {
     public String buildUrl(final String apiKey) {
         return String.format("%s://%s:%s/app/%s%s", encrypted ? WSS_SCHEME : WS_SCHEME, host, encrypted ? wssPort
                 : wsPort, apiKey, URI_SUFFIX);
+    }
+
+    /**
+     *
+     * The default value is Proxy.NO_PROXY.
+     *
+     * @param proxy
+     *            Specify a proxy, e.g. <code>options.setProxy( new Proxy( Proxy.Type.HTTP, new InetSocketAddress( "proxyaddress", 80 ) ) )</code>;
+     * @return this, for chaining
+     */
+    public PusherOptions setProxy(Proxy proxy){
+        this.proxy = proxy;
+        return this;
+    }
+
+    public Proxy getProxy() {
+        if (this.proxy == null) {
+            return Proxy.NO_PROXY;
+        } else {
+            return this.proxy;
+        }
     }
 
     private static String readVersionFromProperties() {

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketClientWrapper.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketClientWrapper.java
@@ -1,6 +1,7 @@
 package com.pusher.client.connection.websocket;
 
 import java.io.IOException;
+import java.net.Proxy;
 import java.net.URI;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
@@ -21,9 +22,9 @@ import org.java_websocket.handshake.ServerHandshake;
 public class WebSocketClientWrapper extends WebSocketClient {
 
     private static final String WSS_SCHEME = "wss";
-    private final WebSocketListener proxy;
+    private final WebSocketListener webSocketListener;
 
-    public WebSocketClientWrapper(final URI uri, final WebSocketListener proxy) throws SSLException {
+    public WebSocketClientWrapper(final URI uri, final Proxy proxy, final WebSocketListener webSocketListener) throws SSLException {
         super(uri);
 
         if (uri.getScheme().equals(WSS_SCHEME)) {
@@ -51,27 +52,27 @@ public class WebSocketClientWrapper extends WebSocketClient {
                 throw new SSLException(e);
             }
         }
-
-        this.proxy = proxy;
+        this.webSocketListener = webSocketListener;
+        setProxy(proxy);
     }
 
     @Override
     public void onOpen(final ServerHandshake handshakedata) {
-        proxy.onOpen(handshakedata);
+        webSocketListener.onOpen(handshakedata);
     }
 
     @Override
     public void onMessage(final String message) {
-        proxy.onMessage(message);
+        webSocketListener.onMessage(message);
     }
 
     @Override
     public void onClose(final int code, final String reason, final boolean remote) {
-        proxy.onClose(code, reason, remote);
+        webSocketListener.onClose(code, reason, remote);
     }
 
     @Override
     public void onError(final Exception ex) {
-        proxy.onError(ex);
+        webSocketListener.onError(ex);
     }
 }

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -1,5 +1,6 @@
 package com.pusher.client.connection.websocket;
 
+import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
@@ -34,15 +35,21 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
     private final ActivityTimer activityTimer;
     private final Map<ConnectionState, Set<ConnectionEventListener>> eventListeners = new HashMap<ConnectionState, Set<ConnectionEventListener>>();
     private final URI webSocketUri;
+    private final Proxy proxy;
 
     private volatile ConnectionState state = ConnectionState.DISCONNECTED;
     private WebSocketClient underlyingConnection;
     private String socketId;
 
-    public WebSocketConnection(final String url, final long activityTimeout, final long pongTimeout,
+    public WebSocketConnection(
+            final String url,
+            final long activityTimeout,
+            final long pongTimeout,
+            final Proxy proxy,
             final Factory factory) throws URISyntaxException {
         webSocketUri = new URI(url);
         activityTimer = new ActivityTimer(activityTimeout, pongTimeout);
+        this.proxy = proxy;
         this.factory = factory;
 
         for (final ConnectionState state : ConnectionState.values()) {
@@ -55,13 +62,13 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
     @Override
     public void connect() {
         factory.getEventQueue().execute(new Runnable() {
+
             @Override
             public void run() {
                 if (state == ConnectionState.DISCONNECTED) {
                     try {
                         underlyingConnection = factory
-                                .newWebSocketClientWrapper(webSocketUri, WebSocketConnection.this);
-
+                                .newWebSocketClientWrapper(webSocketUri, proxy, WebSocketConnection.this);
                         updateState(ConnectionState.CONNECTING);
                         underlyingConnection.connect();
                     }

--- a/src/main/java/com/pusher/client/util/Factory.java
+++ b/src/main/java/com/pusher/client/util/Factory.java
@@ -1,5 +1,6 @@
 package com.pusher.client.util;
 
+import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.concurrent.ExecutorService;
@@ -54,7 +55,7 @@ public class Factory {
         if (connection == null) {
             try {
                 connection = new WebSocketConnection(options.buildUrl(apiKey), options.getActivityTimeout(),
-                        options.getPongTimeout(), this);
+                        options.getPongTimeout(), options.getProxy(), this);
             }
             catch (final URISyntaxException e) {
                 throw new IllegalArgumentException("Failed to initialise connection", e);
@@ -63,8 +64,8 @@ public class Factory {
         return connection;
     }
 
-    public WebSocketClient newWebSocketClientWrapper(final URI uri, final WebSocketListener proxy) throws SSLException {
-        return new WebSocketClientWrapper(uri, proxy);
+    public WebSocketClient newWebSocketClientWrapper(final URI uri, final Proxy proxy, final WebSocketListener webSocketListener) throws SSLException {
+        return new WebSocketClientWrapper(uri, proxy, webSocketListener);
     }
 
     public synchronized ExecutorService getEventQueue() {

--- a/src/test/java/com/pusher/client/PusherOptionsTest.java
+++ b/src/test/java/com/pusher/client/PusherOptionsTest.java
@@ -8,6 +8,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
+
 @RunWith(MockitoJUnitRunner.class)
 public class PusherOptionsTest {
 
@@ -93,4 +97,17 @@ public class PusherOptionsTest {
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://subdomain.example.com:8080/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }
+
+    @Test
+    public void testSetProxy(){
+        Proxy newProxy = new Proxy( Proxy.Type.HTTP, new InetSocketAddress( "proxyaddress", 80 ) );
+        pusherOptions.setProxy(newProxy);
+        assertEquals(pusherOptions.getProxy(), newProxy);
+    }
+
+    @Test
+    public void testGetProxyReturnDefaultProxy(){
+        assertEquals(pusherOptions.getProxy(), Proxy.NO_PROXY);
+    }
+
 }

--- a/src/test/java/com/pusher/client/TestWebSocketClientWrapper.java
+++ b/src/test/java/com/pusher/client/TestWebSocketClientWrapper.java
@@ -2,6 +2,7 @@ package com.pusher.client;
 
 import static org.junit.Assert.*;
 
+import java.net.Proxy;
 import java.net.URI;
 import java.nio.channels.NotYetConnectedException;
 import java.util.ArrayList;
@@ -17,8 +18,8 @@ public class TestWebSocketClientWrapper extends WebSocketClientWrapper {
     private final List<String> messagesSent = new ArrayList<String>();
     private boolean connectCalled = false;
 
-    public TestWebSocketClientWrapper(final URI uri, final WebSocketListener proxy) throws SSLException {
-        super(uri, proxy);
+    public TestWebSocketClientWrapper(final URI uri, final Proxy proxy, final WebSocketListener webSocketListener) throws SSLException {
+        super(uri, proxy, webSocketListener);
     }
 
     void assertConnectCalled() {

--- a/src/test/java/com/pusher/client/connection/websocket/WebSocketClientWrapperTest.java
+++ b/src/test/java/com/pusher/client/connection/websocket/WebSocketClientWrapperTest.java
@@ -2,6 +2,7 @@ package com.pusher.client.connection.websocket;
 
 import static org.mockito.Mockito.verify;
 
+import java.net.Proxy;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -18,36 +19,37 @@ import org.mockito.runners.MockitoJUnitRunner;
 public class WebSocketClientWrapperTest {
 
     private WebSocketClientWrapper wrapper;
-    private @Mock WebSocketListener mockProxy;
+    private @Mock WebSocketListener mockListener;
     private @Mock ServerHandshake mockHandshake;
+    private Proxy mockProxy = Proxy.NO_PROXY;
 
     @Before
     public void setUp() throws URISyntaxException, SSLException {
-        wrapper = new WebSocketClientWrapper(new URI("http://www.test.com"), mockProxy);
+        wrapper = new WebSocketClientWrapper(new URI("http://www.test.com"), mockProxy, mockListener);
     }
 
     @Test
-    public void testOnOpenCallIsDelegatedToTheProxy() {
+    public void testOnOpenCallIsDelegatedToTheListener() {
         wrapper.onOpen(mockHandshake);
-        verify(mockProxy).onOpen(mockHandshake);
+        verify(mockListener).onOpen(mockHandshake);
     }
 
     @Test
-    public void testOnMessageIsDelegatedToTheProxy() {
+    public void testOnMessageIsDelegatedToTheListener() {
         wrapper.onMessage("hello");
-        verify(mockProxy).onMessage("hello");
+        verify(mockListener).onMessage("hello");
     }
 
     @Test
-    public void testOnCloseIsDelegatedToTheProxy() {
+    public void testOnCloseIsDelegatedToTheListener() {
         wrapper.onClose(1, "reason", true);
-        verify(mockProxy).onClose(1, "reason", true);
+        verify(mockListener).onClose(1, "reason", true);
     }
 
     @Test
-    public void testOnErrorIsDelegatedToTheProxy() {
+    public void testOnErrorIsDelegatedToTheListener() {
         final Exception e = new Exception();
         wrapper.onError(e);
-        verify(mockProxy).onError(e);
+        verify(mockListener).onError(e);
     }
 }


### PR DESCRIPTION
* Forward a `setProxy` method in `PusherOptions` on to the underlying java-websocket connection
* + Rename 'proxy' in WebsocketClientWrapper to 'websocketListener' to avoid confusion

Tests coming up...

