### PR TITLE
Removed superfluous code

### DIFF
--- a/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
@@ -53,10 +53,7 @@ public class ChannelManager implements ConnectionEventListener {
     }
 
     private InternalChannel findChannelInChannelMap(String channelName){
-        if (channelNameToChannelMap.containsKey(channelName)){
-            return channelNameToChannelMap.get(channelName);
-        }
-        return null;
+        return channelNameToChannelMap.get(channelName);
     }
 
     public void setConnection(final InternalConnection connection) {


### PR DESCRIPTION
get() on a Map object returns null if the key does not exist.