### PR TITLE
Added unsubscribedlistener

### DIFF
--- a/src/main/java/com/pusher/client/channel/ChannelEventListener.java
+++ b/src/main/java/com/pusher/client/channel/ChannelEventListener.java
@@ -40,4 +40,15 @@ public interface ChannelEventListener extends SubscriptionEventListener {
      *            The name of the channel that was successfully subscribed.
      */
     void onSubscriptionSucceeded(String channelName);
+
+    /**
+     * <p>
+     * Callback that is fired when the channel state has been updated to
+     * ChannelState.UNSUBSCRIBED and getChannel(channelName) will return null.
+     * </p>
+     *
+     * @param channelName
+     *            The name of the channel that is no longer subscribed.
+     */
+    void onChannelUnsubscribed(String channelName);
 }

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -161,6 +161,13 @@ public class ChannelImpl implements InternalChannel {
                     eventListener.onSubscriptionSucceeded(ChannelImpl.this.getName());
                 }
             });
+        } else if (state == ChannelState.UNSUBSCRIBED && eventListener != null) {
+            factory.getEventQueue().execute(new Runnable() {
+                @Override
+                public void run() {
+                    eventListener.onChannelUnsubscribed(ChannelImpl.this.getName());
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Added additional event listener callback for when a channel state is updated to unsubscribed.

This is useful in apps that have many channel subscriptions that are altered based on user status (such as away, offline, etc. in a messaging app) or in an app that has multiple user profiles with different associated channel subscriptions.  In these cases, the developer may not want the app's UI to update until channel unsubscriptions are complete and providing a callback method in the Pusher library allows developers to avoid creating their own tertiary thread to "watch" channel statuses.
