### PR TITLE
General code quality fix-2

### DIFF
--- a/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
@@ -183,7 +183,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
     @SuppressWarnings("rawtypes")
     private static PresenceData extractPresenceDataFrom(final String message) {
         final String dataString = extractDataStringFrom(message);
-        return GSON.fromJson(dataString, Presence.class).presence;
+        return GSON.fromJson(dataString, Presence.class).presenceData;
     }
 
     @SuppressWarnings("rawtypes")
@@ -210,7 +210,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
 
     private class Presence {
         @SerializedName("presence")
-        public PresenceData presence;
+        public PresenceData presenceData;
     }
 
 }

--- a/src/main/java/com/pusher/client/example/ExampleApp.java
+++ b/src/main/java/com/pusher/client/example/ExampleApp.java
@@ -17,10 +17,6 @@ public class ExampleApp implements ConnectionEventListener, ChannelEventListener
     private final String eventName;
     private final long startTime = System.currentTimeMillis();
 
-    public static void main(final String[] args) {
-        new ExampleApp(args);
-    }
-
     public ExampleApp(final String[] args) {
 
         final String apiKey = args.length > 0 ? args[0] : "161717a55e65825bacf1";
@@ -43,6 +39,10 @@ public class ExampleApp implements ConnectionEventListener, ChannelEventListener
                 e.printStackTrace();
             }
         }
+    }
+    
+    public static void main(final String[] args) {
+        new ExampleApp(args);
     }
 
     /* ConnectionEventListener implementation */

--- a/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
@@ -19,10 +19,6 @@ public class PresenceChannelExampleApp implements ConnectionEventListener, Prese
 
     private final PresenceChannel channel;
 
-    public static void main(final String[] args) {
-        new PresenceChannelExampleApp(args);
-    }
-
     public PresenceChannelExampleApp(final String[] args) {
 
         final String apiKey = args.length > 0 ? args[0] : "a87fe72c6f36272aa4b1";
@@ -48,6 +44,10 @@ public class PresenceChannelExampleApp implements ConnectionEventListener, Prese
                 e.printStackTrace();
             }
         }
+    }
+    
+    public static void main(final String[] args) {
+        new PresenceChannelExampleApp(args);
     }
 
     /* ConnectionEventListener implementation */

--- a/src/main/java/com/pusher/client/example/PrivateChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateChannelExampleApp.java
@@ -16,10 +16,6 @@ public class PrivateChannelExampleApp implements ConnectionEventListener, Privat
 
     private final PrivateChannel channel;
 
-    public static void main(final String[] args) {
-        new PrivateChannelExampleApp(args);
-    }
-
     public PrivateChannelExampleApp(final String[] args) {
 
         final String apiKey = args.length > 0 ? args[0] : "a87fe72c6f36272aa4b1";
@@ -45,6 +41,10 @@ public class PrivateChannelExampleApp implements ConnectionEventListener, Privat
                 e.printStackTrace();
             }
         }
+    }
+    
+    public static void main(final String[] args) {
+        new PrivateChannelExampleApp(args);
     }
 
     /* ConnectionEventListener implementation */

--- a/src/main/java/com/pusher/client/example/SimpleWebSocket.java
+++ b/src/main/java/com/pusher/client/example/SimpleWebSocket.java
@@ -7,16 +7,17 @@ import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 
 public class SimpleWebSocket extends WebSocketClient {
-    public static void main(final String[] args) throws URISyntaxException {
-        new SimpleWebSocket();
-    }
-
+    
     public SimpleWebSocket() throws URISyntaxException {
         super(new URI("ws://ws.pusherapp.com/app/387954142406c3c9cc13?protocol=6&client=js&version=0.1.2&flash=false"));
 
         System.out.println("SimpleWebSocket");
 
         connect();
+    }
+    
+    public static void main(final String[] args) throws URISyntaxException {
+        new SimpleWebSocket();
     }
 
     @Override

--- a/src/main/java/com/pusher/client/util/HttpAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpAuthorizer.java
@@ -37,7 +37,7 @@ public class HttpAuthorizer implements Authorizer {
     private final URL endPoint;
     private Map<String, String> mHeaders = new HashMap<String, String>();
     private Map<String, String> mQueryStringParameters = new HashMap<String, String>();
-    private final String ENCODING_CHARACTER_SET = "UTF-8";
+    private final static String ENCODING_CHARACTER_SET = "UTF-8";
 
     /**
      * Creates a new authorizer.
@@ -78,7 +78,7 @@ public class HttpAuthorizer implements Authorizer {
      * @param queryStringParameters
      *            the query parameters
      */
-    public void setQueryStringParameters(final HashMap<String, String> queryStringParameters) {
+    public void setQueryStringParameters(final Map<String, String> queryStringParameters) {
         mQueryStringParameters = queryStringParameters;
     }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S1319 - Declarations should use Java collection interfaces.
squid:S1170 - Public constants should be declared "static final" rather than merely "final".
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1700 - A field should not duplicate the name of its containing class.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1319
https://dev.eclipse.org/sonar/rules/show/squid:S1170
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1700

Please let me know if you have any questions.

Faisal Hameed
