### PR TITLE
General code quality fix-3

### DIFF
--- a/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
@@ -33,7 +33,7 @@ public class ChannelManager implements ConnectionEventListener {
         } else if (channelName.startsWith("presence-")){
             throw new IllegalArgumentException("Please use the getPresenceChannel method");
         }
-        return (Channel) findChannelInChannelMap(channelName);
+        return findChannelInChannelMap(channelName);
     }
 
     public PrivateChannel getPrivateChannel(String channelName) throws IllegalArgumentException{

--- a/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
@@ -88,9 +88,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
 
             jsonObject.put("data", dataMap);
 
-            final String json = GSON.toJson(jsonObject);
-
-            return json;
+            return GSON.toJson(jsonObject);
         }
         catch (final Exception e) {
             throw new AuthorizationFailureException("Unable to parse response from Authorizer: " + authResponse, e);
@@ -199,7 +197,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
         public Object userInfo;
     }
 
-    private class PresenceData {
+    private static class PresenceData {
         @SerializedName("count")
         public Integer count;
         @SerializedName("ids")

--- a/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
@@ -100,8 +100,7 @@ public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
 
             jsonObject.put("data", dataMap);
 
-            final String json = new Gson().toJson(jsonObject);
-            return json;
+            return new Gson().toJson(jsonObject);
         }
         catch (final Exception e) {
             throw new AuthorizationFailureException("Unable to parse response from Authorizer: " + authResponse, e);

--- a/src/main/java/com/pusher/client/util/HttpAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpAuthorizer.java
@@ -111,7 +111,7 @@ public class HttpAuthorizer implements Authorizer {
             connection.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
             connection.setRequestProperty("charset", "utf-8");
             connection.setRequestProperty("Content-Length",
-                    "" + Integer.toString(urlParameters.toString().getBytes().length));
+                    "" + Integer.toString(urlParameters.toString().getBytes(ENCODING_CHARACTER_SET).length));
 
             // Add in the user defined headers
             for (final String headerName : mHeaders.keySet()) {
@@ -129,7 +129,7 @@ public class HttpAuthorizer implements Authorizer {
 
             // Read response
             final InputStream is = connection.getInputStream();
-            final BufferedReader rd = new BufferedReader(new InputStreamReader(is));
+            final BufferedReader rd = new BufferedReader(new InputStreamReader(is, ENCODING_CHARACTER_SET));
             String line;
             final StringBuffer response = new StringBuffer();
             while ((line = rd.readLine()) != null) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules 
squid:S2694 - Inner classes which do not reference their owning classes should be "static".
squid:S1488 - Local Variables should not be declared and then immediately returned or thrown.
squid:S1943 - Classes and methods that rely on the default system encoding should not be used.
squid:S1905 - Redundant casts should not be used
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S2694
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1943
https://dev.eclipse.org/sonar/rules/show/squid:S1905

Please let me know if you have any questions.

Faisal Hameed
