### PR TITLE
Reduce construction of Gson objects and keep one centralized instance in Factory

### DIFF
--- a/src/main/java/com/pusher/client/channel/User.java
+++ b/src/main/java/com/pusher/client/channel/User.java
@@ -7,7 +7,7 @@ import com.google.gson.Gson;
  * {@link com.pusher.client.channel.PresenceChannel PresenceChannel}.
  */
 public class User {
-
+    private static final Gson GSON = new Gson();
     private final String id;
     private final String jsonData;
 
@@ -80,7 +80,7 @@ public class User {
      * @return V An instance of clazz, populated with the user info
      */
     public <V> V getInfo(final Class<V> clazz) {
-        return new Gson().fromJson(jsonData, clazz);
+        return GSON.fromJson(jsonData, clazz);
     }
 
     @Override

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -16,6 +16,7 @@ import com.pusher.client.util.Factory;
 
 public class ChannelImpl implements InternalChannel {
 
+    private static final Gson GSON = new Gson();
     private static final String INTERNAL_EVENT_PREFIX = "pusher_internal:";
     protected static final String SUBSCRIPTION_SUCCESS_EVENT = "pusher_internal:subscription_succeeded";
     protected final String name;
@@ -133,7 +134,7 @@ public class ChannelImpl implements InternalChannel {
 
         jsonObject.put("data", dataMap);
 
-        return new Gson().toJson(jsonObject);
+        return GSON.toJson(jsonObject);
     }
 
     @Override
@@ -146,7 +147,7 @@ public class ChannelImpl implements InternalChannel {
 
         jsonObject.put("data", dataMap);
 
-        return new Gson().toJson(jsonObject);
+        return GSON.toJson(jsonObject);
     }
 
     @Override
@@ -190,8 +191,7 @@ public class ChannelImpl implements InternalChannel {
 
     @SuppressWarnings("unchecked")
     private String extractDataFrom(final String message) {
-        final Gson gson = new Gson();
-        final Map<Object, Object> jsonObject = gson.fromJson(message, Map.class);
+        final Map<Object, Object> jsonObject = GSON.fromJson(message, Map.class);
         return (String)jsonObject.get("data");
     }
 

--- a/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
@@ -19,6 +19,7 @@ import com.pusher.client.util.Factory;
 
 public class ChannelManager implements ConnectionEventListener {
 
+    private static final Gson GSON = new Gson();
     private final Map<String, InternalChannel> channelNameToChannelMap = new HashMap<String, InternalChannel>();
     private final Factory factory;
     private InternalConnection connection;
@@ -96,7 +97,7 @@ public class ChannelManager implements ConnectionEventListener {
     @SuppressWarnings("unchecked")
     public void onMessage(final String event, final String wholeMessage) {
 
-        final Map<Object, Object> json = new Gson().fromJson(wholeMessage, Map.class);
+        final Map<Object, Object> json = GSON.fromJson(wholeMessage, Map.class);
         final Object channelNameObject = json.get("channel");
 
         if (channelNameObject != null) {

--- a/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
@@ -18,6 +18,7 @@ import com.pusher.client.util.Factory;
 
 public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
 
+    private static final Gson GSON = new Gson();
     private static final String CLIENT_EVENT_PREFIX = "client-";
     private final InternalConnection connection;
     private final Authorizer authorizer;
@@ -51,14 +52,14 @@ public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
         }
 
         try {
-            final Map userData = new Gson().fromJson(data, Map.class);
+            final Map userData = GSON.fromJson(data, Map.class);
 
             final Map<Object, Object> jsonPayload = new LinkedHashMap<Object, Object>();
             jsonPayload.put("event", eventName);
             jsonPayload.put("channel", name);
             jsonPayload.put("data", userData);
 
-            final String jsonMessage = new Gson().toJson(jsonPayload);
+            final String jsonMessage = GSON.toJson(jsonPayload);
             connection.sendMessage(jsonMessage);
 
         }
@@ -88,7 +89,7 @@ public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
         final String authResponse = getAuthResponse();
 
         try {
-            final Map authResponseMap = new Gson().fromJson(authResponse, Map.class);
+            final Map authResponseMap = GSON.fromJson(authResponse, Map.class);
             final String authKey = (String)authResponseMap.get("auth");
 
             final Map<Object, Object> jsonObject = new LinkedHashMap<Object, Object>();
@@ -100,7 +101,7 @@ public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
 
             jsonObject.put("data", dataMap);
 
-            final String json = new Gson().toJson(jsonObject);
+            final String json = GSON.toJson(jsonObject);
             return json;
         }
         catch (final Exception e) {

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -28,6 +28,7 @@ import com.pusher.client.util.Factory;
 
 public class WebSocketConnection implements InternalConnection, WebSocketListener {
     private static final Logger log = LoggerFactory.getLogger(WebSocketConnection.class);
+    private static final Gson GSON = new Gson();
 
     private static final String INTERNAL_EVENT_PREFIX = "pusher:";
     static final String PING_EVENT_SERIALIZED = "{\"event\": \"pusher:ping\"}";
@@ -178,9 +179,9 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
 
     @SuppressWarnings("rawtypes")
     private void handleConnectionMessage(final String message) {
-        final Map jsonObject = new Gson().fromJson(message, Map.class);
+        final Map jsonObject = GSON.fromJson(message, Map.class);
         final String dataString = (String)jsonObject.get("data");
-        final Map dataMap = new Gson().fromJson(dataString, Map.class);
+        final Map dataMap = GSON.fromJson(dataString, Map.class);
         socketId = (String)dataMap.get("socket_id");
 
         updateState(ConnectionState.CONNECTED);
@@ -188,12 +189,12 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
 
     @SuppressWarnings("rawtypes")
     private void handleError(final String wholeMessage) {
-        final Map json = new Gson().fromJson(wholeMessage, Map.class);
+        final Map json = GSON.fromJson(wholeMessage, Map.class);
         final Object data = json.get("data");
 
         Map dataMap;
         if (data instanceof String) {
-            dataMap = new Gson().fromJson((String)data, Map.class);
+            dataMap = GSON.fromJson((String)data, Map.class);
         }
         else {
             dataMap = (Map)data;
@@ -241,7 +242,7 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
         factory.queueOnEventThread(new Runnable() {
             @Override
             public void run() {
-                final Map<String, String> map = new Gson().fromJson(message, Map.class);
+                final Map<String, String> map = GSON.fromJson(message, Map.class);
                 final String event = map.get("event");
                 handleEvent(event, message);
             }


### PR DESCRIPTION
There are a lot of operations that occur upon construction of a `Gson` object so it seems wrong to be allocating such an object upon each piece of JSON received by the client or sent to your servers. This puts the allocation of a single `Gson` object in `Factory` so that a single instance can reused across the usage of a `Pusher` object.