### PR TITLE
Immediately set connection state to disconnected due to a pong timeout

### DIFF
--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketClientWrapper.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketClientWrapper.java
@@ -22,15 +22,14 @@ import org.java_websocket.handshake.ServerHandshake;
 public class WebSocketClientWrapper extends WebSocketClient {
 
     private static final String WSS_SCHEME = "wss";
-    private final WebSocketListener webSocketListener;
+    private WebSocketListener webSocketListener;
 
     public WebSocketClientWrapper(final URI uri, final Proxy proxy, final WebSocketListener webSocketListener) throws SSLException {
         super(uri);
 
         if (uri.getScheme().equals(WSS_SCHEME)) {
             try {
-                SSLContext sslContext = null;
-                sslContext = SSLContext.getInstance("TLS");
+                SSLContext sslContext = SSLContext.getInstance("TLS");
                 sslContext.init(null, null, null); // will use java's default
                                                    // key and trust store which
                                                    // is sufficient unless you
@@ -58,21 +57,36 @@ public class WebSocketClientWrapper extends WebSocketClient {
 
     @Override
     public void onOpen(final ServerHandshake handshakedata) {
-        webSocketListener.onOpen(handshakedata);
+        if (webSocketListener != null) {
+            webSocketListener.onOpen(handshakedata);
+        }
     }
 
     @Override
     public void onMessage(final String message) {
-        webSocketListener.onMessage(message);
+        if (webSocketListener != null) {
+            webSocketListener.onMessage(message);
+        }
     }
 
     @Override
     public void onClose(final int code, final String reason, final boolean remote) {
-        webSocketListener.onClose(code, reason, remote);
+        if (webSocketListener != null) {
+            webSocketListener.onClose(code, reason, remote);
+        }
     }
 
     @Override
     public void onError(final Exception ex) {
-        webSocketListener.onError(ex);
+        if (webSocketListener != null) {
+            webSocketListener.onError(ex);
+        }
+    }
+
+    /**
+     * Removes the WebSocketListener so that the underlying WebSocketClient doesn't expose any listener events.
+     */
+    public void removeWebSocketListener() {
+        webSocketListener = null;
     }
 }

--- a/src/main/java/com/pusher/client/util/Factory.java
+++ b/src/main/java/com/pusher/client/util/Factory.java
@@ -62,7 +62,7 @@ public class Factory {
         return connection;
     }
 
-    public WebSocketClient newWebSocketClientWrapper(final URI uri, final Proxy proxy, final WebSocketListener webSocketListener) throws SSLException {
+    public WebSocketClientWrapper newWebSocketClientWrapper(final URI uri, final Proxy proxy, final WebSocketListener webSocketListener) throws SSLException {
         return new WebSocketClientWrapper(uri, proxy, webSocketListener);
     }
 

--- a/src/test/java/com/pusher/client/connection/websocket/WebSocketClientWrapperTest.java
+++ b/src/test/java/com/pusher/client/connection/websocket/WebSocketClientWrapperTest.java
@@ -13,6 +13,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.internal.verification.NoMoreInteractions;
 import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -51,5 +52,16 @@ public class WebSocketClientWrapperTest {
         final Exception e = new Exception();
         wrapper.onError(e);
         verify(mockListener).onError(e);
+    }
+
+    @Test
+    public void testRemoveWebSocketListener() {
+        wrapper.onClose(1, "reason", true);
+        verify(mockListener).onClose(1, "reason", true);
+
+        wrapper.removeWebSocketListener();
+
+        wrapper.onClose(1, "reason", true);
+        verify(mockListener, new NoMoreInteractions()).onClose(1, "reason", true);
     }
 }

--- a/src/test/java/com/pusher/client/connection/websocket/WebSocketConnectionTest.java
+++ b/src/test/java/com/pusher/client/connection/websocket/WebSocketConnectionTest.java
@@ -246,7 +246,7 @@ public class WebSocketConnectionTest {
         connection.disconnect();
         verify(mockEventListener).onConnectionStateChange(
                 new ConnectionStateChange(ConnectionState.CONNECTED, ConnectionState.DISCONNECTING));
-        assertEquals(ConnectionState.DISCONNECTING, connection.getState());
+        assertEquals(ConnectionState.DISCONNECTED, connection.getState());
     }
 
     @Test
@@ -275,7 +275,27 @@ public class WebSocketConnectionTest {
         connection.disconnect();
 
         verify(mockUnderlyingConnection, times(1)).close();
-        verify(mockEventListener, times(3)).onConnectionStateChange(any(ConnectionStateChange.class));
+        verify(mockEventListener, times(4)).onConnectionStateChange(any(ConnectionStateChange.class));
+    }
+
+    @Test
+    public void testDisconnectImmediatelyCallsOnClose() {
+        connection.connect();
+        verify(mockEventListener).onConnectionStateChange(
+                new ConnectionStateChange(ConnectionState.DISCONNECTED, ConnectionState.CONNECTING));
+
+        connection.onMessage(CONN_ESTABLISHED_EVENT);
+        verify(mockEventListener).onConnectionStateChange(
+                new ConnectionStateChange(ConnectionState.CONNECTING, ConnectionState.CONNECTED));
+
+        connection.disconnect();
+        verify(mockEventListener).onConnectionStateChange(
+                new ConnectionStateChange(ConnectionState.CONNECTED, ConnectionState.DISCONNECTING));
+
+        verify(mockEventListener).onConnectionStateChange(
+                new ConnectionStateChange(ConnectionState.DISCONNECTING, ConnectionState.DISCONNECTED));
+
+        assertEquals(ConnectionState.DISCONNECTED, connection.getState());
     }
 
     /* end of tests */


### PR DESCRIPTION
The underlying WebSocketClient connection will attempt to perform a WebSocket compliant graceful shutdown.

But in the case where a disconnect was called due to the client not receiving a pong, this will likely not succeed, which would delay the change to DISCONNECTED.