### PR TITLE
Accept 201 status code from auth endpoints

### DIFF
--- a/src/main/java/com/pusher/client/util/HttpAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpAuthorizer.java
@@ -138,7 +138,7 @@ public class HttpAuthorizer implements Authorizer {
             rd.close();
 
             final int responseHttpStatus = connection.getResponseCode();
-            if (responseHttpStatus != 200) {
+            if (responseHttpStatus != 200 && responseHttpStatus != 201) {
                 throw new AuthorizationFailureException(response.toString());
             }
 


### PR DESCRIPTION
While strictly incorrect (201 describes the creation of a new HTTP
resource, the URI of which is reported in the Location header), some
other client libraries have long accepted 201 responses, and people have
tested their implementations only with such libraries.

@jpatel531  