### PR TITLE
Removing unneeded parsing to JSON

### DIFF
--- a/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
@@ -52,12 +52,11 @@ public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
         }
 
         try {
-            final Map userData = GSON.fromJson(data, Map.class);
 
             final Map<Object, Object> jsonPayload = new LinkedHashMap<Object, Object>();
             jsonPayload.put("event", eventName);
             jsonPayload.put("channel", name);
-            jsonPayload.put("data", userData);
+            jsonPayload.put("data", data);
 
             final String jsonMessage = GSON.toJson(jsonPayload);
             connection.sendMessage(jsonMessage);


### PR DESCRIPTION
Removing unneeded parsing of payload into a JSON object

https://github.com/pusher/pusher-websocket-java/issues/122

Primary reasoning is that iOS doesn't do this, so why restrict Android's functionality