### PR TITLE
Synchronise access to channelNameToChannelMap

### DIFF
--- a/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelManager.java
@@ -1,7 +1,7 @@
 package com.pusher.client.channel.impl;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import com.google.gson.Gson;
 import com.pusher.client.AuthorizationFailureException;
@@ -20,7 +20,8 @@ import com.pusher.client.util.Factory;
 public class ChannelManager implements ConnectionEventListener {
 
     private static final Gson GSON = new Gson();
-    private final Map<String, InternalChannel> channelNameToChannelMap = new HashMap<String, InternalChannel>();
+    private final Map<String, InternalChannel> channelNameToChannelMap = new ConcurrentHashMap<String, InternalChannel>();
+
     private final Factory factory;
     private InternalConnection connection;
 
@@ -70,8 +71,7 @@ public class ChannelManager implements ConnectionEventListener {
         connection.bind(ConnectionState.CONNECTED, this);
     }
 
-    public void subscribeTo(final InternalChannel channel, final ChannelEventListener listener,
-            final String... eventNames) {
+    public void subscribeTo(final InternalChannel channel, final ChannelEventListener listener, final String... eventNames) {
 
         validateArgumentsAndBindEvents(channel, listener, eventNames);
         channelNameToChannelMap.put(channel.getName(), channel);
@@ -88,7 +88,6 @@ public class ChannelManager implements ConnectionEventListener {
         if (channel == null) {
             return;
         }
-
         if (connection.getState() == ConnectionState.CONNECTED) {
             sendUnsubscribeMessage(channel);
         }
@@ -116,8 +115,7 @@ public class ChannelManager implements ConnectionEventListener {
     public void onConnectionStateChange(final ConnectionStateChange change) {
 
         if (change.getCurrentState() == ConnectionState.CONNECTED) {
-
-            for (final InternalChannel channel : channelNameToChannelMap.values()) {
+            for(final InternalChannel channel : channelNameToChannelMap.values()){
                 sendOrQueueSubscribeMessage(channel);
             }
         }
@@ -181,8 +179,7 @@ public class ChannelManager implements ConnectionEventListener {
         }
     }
 
-    private void validateArgumentsAndBindEvents(final InternalChannel channel, final ChannelEventListener listener,
-            final String... eventNames) {
+    private void validateArgumentsAndBindEvents(final InternalChannel channel, final ChannelEventListener listener, final String... eventNames) {
 
         if (channel == null) {
             throw new IllegalArgumentException("Cannot subscribe to a null channel");


### PR DESCRIPTION
This would avoid the ConcurrentModificationException if unsubscribe/subscribe happens when connecting to the channel. 