### PR TITLE
Enable additional body types for POST authorization

### DIFF
--- a/src/main/java/com/pusher/client/util/HttpAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpAuthorizer.java
@@ -157,6 +157,6 @@ public class HttpAuthorizer implements Authorizer {
             urlParameters.append(URLEncoder.encode(mQueryStringParameters.get(parameterName),
                     ENCODING_CHARACTER_SET));
         }
-        return urlParameters.toString()
+        return urlParameters.toString();
     }
 }

--- a/src/main/java/com/pusher/client/util/HttpAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpAuthorizer.java
@@ -145,17 +145,21 @@ public class HttpAuthorizer implements Authorizer {
         }
     }
 
-    protected String bodyFactory(final String channelName, final String socketId) {
-        final StringBuffer urlParameters = new StringBuffer();
-        urlParameters.append("channel_name=").append(URLEncoder.encode(channelName, ENCODING_CHARACTER_SET));
-        urlParameters.append("&socket_id=").append(URLEncoder.encode(socketId, ENCODING_CHARACTER_SET));
+    protected String bodyFactory(final String channelName, final String socketId) throws Exception {
+        try {
+            final StringBuffer urlParameters = new StringBuffer();
+            urlParameters.append("channel_name=").append(URLEncoder.encode(channelName, ENCODING_CHARACTER_SET));
+            urlParameters.append("&socket_id=").append(URLEncoder.encode(socketId, ENCODING_CHARACTER_SET));
 
-        // Adding extra parameters supplied to be added to query string.
-        for (final String parameterName : mQueryStringParameters.keySet()) {
-            urlParameters.append("&").append(parameterName).append("=");
-            urlParameters.append(URLEncoder.encode(mQueryStringParameters.get(parameterName),
-                    ENCODING_CHARACTER_SET));
+            // Adding extra parameters supplied to be added to query string.
+            for (final String parameterName : mQueryStringParameters.keySet()) {
+                urlParameters.append("&").append(parameterName).append("=");
+                urlParameters.append(URLEncoder.encode(mQueryStringParameters.get(parameterName),
+                        ENCODING_CHARACTER_SET));
+            }
+            return urlParameters.toString();
+        } catch (final Exception e) {
+            throw e;
         }
-        return urlParameters.toString();
     }
 }

--- a/src/main/java/com/pusher/client/util/HttpAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpAuthorizer.java
@@ -86,7 +86,7 @@ public class HttpAuthorizer implements Authorizer {
     public String authorize(final String channelName, final String socketId) throws AuthorizationFailureException {
 
         try {
-            final String body = new bodyFactory(channelName, socketId);
+            final String body = bodyFactory(channelName, socketId);
 
             final HashMap<String, String> defaultHeaders = new HashMap<String, String>();
             defaultHeaders.put("Content-Type", "application/x-www-form-urlencoded");

--- a/src/main/java/com/pusher/client/util/HttpAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpAuthorizer.java
@@ -145,8 +145,7 @@ public class HttpAuthorizer implements Authorizer {
         }
     }
 
-    @Override
-    private String bodyFactory(final String channelName, final String socketId) {
+    protected String bodyFactory(final String channelName, final String socketId) {
         final StringBuffer urlParameters = new StringBuffer();
         urlParameters.append("channel_name=").append(URLEncoder.encode(channelName, ENCODING_CHARACTER_SET));
         urlParameters.append("&socket_id=").append(URLEncoder.encode(socketId, ENCODING_CHARACTER_SET));


### PR DESCRIPTION
### Description of the pull request
By overriding bodyFactory, it is now possible to send JSON objects in the body, rather than only "Content-Type: application/x-www-form-urlencoded" strings.
Users can also set the correct headers to be sent - for example "Content-Type: application/json", and are able to override the "charset" header as well.

#### Why is the change necessary?
#164
----

CC @pusher/mobile 
