### PR TITLE
Enable additional body types for POST authorization

### DIFF
--- a/src/main/java/com/pusher/client/util/ConnectionFactory.java
+++ b/src/main/java/com/pusher/client/util/ConnectionFactory.java
@@ -1,0 +1,35 @@
+package com.pusher.client.util;
+
+/**
+ * Abstract factory to be used for
+ * building HttpAuthorizer connections
+ */
+public abstract class ConnectionFactory {
+    private String channelName;
+    private String socketId;
+
+    public ConnectionFactory() {
+    }
+
+    public abstract String getBody();
+
+    public abstract String getCharset();
+
+    public abstract String getContentType();
+
+    public String getChannelName() {
+        return channelName;
+    }
+
+    public void setChannelName(String channelName) {
+        this.channelName = channelName;
+    }
+
+    public String getSocketId() {
+        return socketId;
+    }
+
+    public void setSocketId(String socketId) {
+        this.socketId = socketId;
+    }
+}

--- a/src/main/java/com/pusher/client/util/UrlEncodedConnectionFactory.java
+++ b/src/main/java/com/pusher/client/util/UrlEncodedConnectionFactory.java
@@ -1,0 +1,58 @@
+package com.pusher.client.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Form URL-Encoded Connection Factory
+ *
+ * Allows HttpAuthorizer to write URL parameters to the connection
+ */
+public class UrlEncodedConnectionFactory extends ConnectionFactory {
+
+    private Map<String, String> mQueryStringParameters = new HashMap<String, String>();
+
+    /**
+     * Create a Form URL-encoded factory
+     */
+    public UrlEncodedConnectionFactory() {
+    }
+
+    /**
+     * Create a Form URL-encoded factory
+     *
+     * @param queryStringParameters extra parameters that need to be added to query string.
+     */
+    public UrlEncodedConnectionFactory(final Map<String, String> queryStringParameters) {
+        this.mQueryStringParameters = queryStringParameters;
+    }
+
+    @Override
+    public String getCharset() {
+        return "UTF-8";
+    }
+
+    @Override
+    public String getContentType() {
+        return "application/x-www-form-urlencoded";
+    }
+
+    public String getBody() {
+        final StringBuffer urlParameters = new StringBuffer();
+        try {
+            urlParameters.append("channel_name=").append(URLEncoder.encode(getChannelName(), getCharset()));
+            urlParameters.append("&socket_id=").append(URLEncoder.encode(getSocketId(), getCharset()));
+
+            // Adding extra parameters supplied to be added to query string.
+            for (final String parameterName : mQueryStringParameters.keySet()) {
+                urlParameters.append("&").append(parameterName).append("=");
+                urlParameters.append(URLEncoder.encode(mQueryStringParameters.get(parameterName), getCharset()));
+            }
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        return urlParameters.toString();
+    }
+}


### PR DESCRIPTION
Note: this is a continuation of PR #165, but aims at tidying up the code as requested by @zmarkan  

### Description of the pull request

By subclassing ConnectionFactory and passing a new instance into the HttpAuthorizer class, it is now possible to send JSON objects in the body, rather than only "Content-Type: application/x-www-form-urlencoded" strings.
Users can also set the correct headers to be sent - for example "Content-Type: application/json", and are able to override the "charset" header as well.

#### Why is the change necessary?

#164

----

CC @pusher/mobile 
