### PR TITLE
Updated protocol version from 5 to 7 in URI

### DIFF
--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -14,7 +14,7 @@ public class PusherOptions {
     private static final String LIB_DEV_VERSION = "0.0.0-dev";
 	public static final String LIB_VERSION = readVersionFromProperties();
 
-    private static final String URI_SUFFIX = "?client=java-client&protocol=5&version=" + LIB_VERSION;
+    private static final String URI_SUFFIX = "?client=java-client&protocol=7&version=" + LIB_VERSION;
     private static final String WS_SCHEME = "ws";
     private static final String WSS_SCHEME = "wss";
 

--- a/src/test/java/com/pusher/client/PusherOptionsTest.java
+++ b/src/test/java/com/pusher/client/PusherOptionsTest.java
@@ -60,42 +60,42 @@ public class PusherOptionsTest {
     @Test
     public void testDefaultURL() {
         assertEquals(pusherOptions.buildUrl(API_KEY), "wss://ws.pusherapp.com:443/app/" + API_KEY
-                + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
+                + "?client=java-client&protocol=7&version=" + PusherOptions.LIB_VERSION);
     }
 
     @Test
     public void testNonSSLURLIsCorrect() {
         pusherOptions.setEncrypted(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://ws.pusherapp.com:80/app/" + API_KEY
-                + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
+                + "?client=java-client&protocol=7&version=" + PusherOptions.LIB_VERSION);
     }
 
     @Test
     public void testClusterSetURLIsCorrect() {
         pusherOptions.setCluster("eu");
         assertEquals(pusherOptions.buildUrl(API_KEY), "wss://ws-eu.pusher.com:443/app/" + API_KEY
-                + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
+                + "?client=java-client&protocol=7&version=" + PusherOptions.LIB_VERSION);
     }
 
     @Test
     public void testClusterSetNonSSLURLIsCorrect() {
         pusherOptions.setCluster("eu").setEncrypted(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://ws-eu.pusher.com:80/app/" + API_KEY
-                + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
+                + "?client=java-client&protocol=7&version=" + PusherOptions.LIB_VERSION);
     }
 
     @Test
     public void testCustomHostAndPortURLIsCorrect() {
         pusherOptions.setHost("subdomain.example.com").setWsPort(8080).setWssPort(8181);
         assertEquals(pusherOptions.buildUrl(API_KEY), "wss://subdomain.example.com:8181/app/" + API_KEY
-                + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
+                + "?client=java-client&protocol=7&version=" + PusherOptions.LIB_VERSION);
     }
 
     @Test
     public void testCustomHostAndPortNonSSLURLIsCorrect() {
         pusherOptions.setHost("subdomain.example.com").setWsPort(8080).setWssPort(8181).setEncrypted(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://subdomain.example.com:8080/app/" + API_KEY
-                + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
+                + "?client=java-client&protocol=7&version=" + PusherOptions.LIB_VERSION);
     }
 
     @Test


### PR DESCRIPTION
### Description of the pull request
Updated the protocol value in the query parameter from 5 to 7.

#### Why is the change necessary?
The change is necessary because it appears to cause an endless loop between the CONNECTING and RECONNECTING states when attempting to connect to some Pusher services. I'm not sure if this is the best solution, or if there is an underlying problem elsewhere with backwards compatibility, but it appears to solve the issue. It might be better to make the protocol version configurable instead.

----

CC @pusher/mobile 
