### PR TITLE
Don't reconnect when codes in 40xx range are received

### DIFF
--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -271,6 +271,10 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
             return;
         }
 
+        if(!shouldReconnect(code)) {
+            updateState(ConnectionState.DISCONNECTING);
+        }
+
         //Reconnection logic
         if(state == ConnectionState.CONNECTED || state == ConnectionState.CONNECTING){
 
@@ -301,6 +305,12 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
                 tryConnecting();
             }
         }, reconnectInterval, TimeUnit.SECONDS);
+    }
+
+    // Received error codes 4000 >= 4099 indicate we shouldn't attempt reconnection
+    // https://pusher.com/docs/pusher_protocol#error-codes
+    private boolean shouldReconnect(int code) {
+        return !(code >= 4000 && code <= 4099);
     }
 
     private void cancelTimeoutsAndTransitonToDisconnected() {

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -307,10 +307,10 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
         }, reconnectInterval, TimeUnit.SECONDS);
     }
 
-    // Received error codes 4000 >= 4099 indicate we shouldn't attempt reconnection
+    // Received error codes 4000-4099 indicate we shouldn't attempt reconnection
     // https://pusher.com/docs/pusher_protocol#error-codes
     private boolean shouldReconnect(int code) {
-        return !(code >= 4000 && code <= 4099);
+        return code < 4000 || code >= 4100;
     }
 
     private void cancelTimeoutsAndTransitonToDisconnected() {

--- a/src/test/java/com/pusher/client/connection/websocket/WebSocketConnectionTest.java
+++ b/src/test/java/com/pusher/client/connection/websocket/WebSocketConnectionTest.java
@@ -316,7 +316,37 @@ public class WebSocketConnectionTest {
         connection.connect();
         connection.onMessage(CONN_ESTABLISHED_EVENT);
 
-        connection.onClose(500, "reason", true);
+        connection.onClose(3999, "reason", true);
+
+        assertEquals(ConnectionState.RECONNECTING, connection.getState());
+    }
+
+    @Test
+    public void stateIsDisconnectedAfterOnCloseWithoutTheUserDisconnectingCode4000() throws InterruptedException, SSLException {
+        connection.connect();
+        connection.onMessage(CONN_ESTABLISHED_EVENT);
+
+        connection.onClose(4000, "reason", true);
+
+        assertEquals(ConnectionState.DISCONNECTED, connection.getState());
+    }
+
+    @Test
+    public void stateIsDisconnectedAfterOnCloseWithoutTheUserDisconnectingCode4099() throws InterruptedException, SSLException {
+        connection.connect();
+        connection.onMessage(CONN_ESTABLISHED_EVENT);
+
+        connection.onClose(4099, "reason", true);
+
+        assertEquals(ConnectionState.DISCONNECTED, connection.getState());
+    }
+
+    @Test
+    public void stateIsDisconnectedAfterOnCloseWithoutTheUserDisconnectingCode4100() throws InterruptedException, SSLException {
+        connection.connect();
+        connection.onMessage(CONN_ESTABLISHED_EVENT);
+
+        connection.onClose(4100, "reason", true);
 
         assertEquals(ConnectionState.RECONNECTING, connection.getState());
     }


### PR DESCRIPTION
### Description of the pull request
Currently, the library ignores Pusher codes and therefore attempts reconnections. I have a feeling this will cause issues with future feature work we may do, so here's a fix.

#### Why is the change necessary?

Respecting protocol.

----

CC @pusher/mobile 
