### PR TITLE
Getter for the underlyingConnection object

### DIFF
--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -65,6 +65,10 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
         }
     }
 
+    public WebSocketClientWrapper getUnderlyingConnection() {
+        return underlyingConnection;
+    }
+
     /* Connection implementation */
 
     @Override


### PR DESCRIPTION
### Description of the pull request

Added a getter for the underlyingConnection object.

#### Why is the change necessary?

So we can directly manipulate the underlying WebSocketClient, in our case to set a socket before connecting. 

----

CC @pusher/mobile 