### PR TITLE
Support receipt of user_id in on client_events on presence channels

### DIFF
--- a/src/main/java/com/pusher/client/channel/EventMetadata.java
+++ b/src/main/java/com/pusher/client/channel/EventMetadata.java
@@ -1,0 +1,15 @@
+package com.pusher.client.channel;
+
+public class EventMetadata {
+    String userId;
+
+    public String getUserId() {
+        return userId;
+    }
+
+
+    public void setUserId(String value) {
+        this.userId = value;
+    }
+
+}

--- a/src/main/java/com/pusher/client/channel/PresenceChannelEventListener.java
+++ b/src/main/java/com/pusher/client/channel/PresenceChannelEventListener.java
@@ -39,4 +39,6 @@ public interface PresenceChannelEventListener extends PrivateChannelEventListene
      *            The user who unsubscribed.
      */
     void userUnsubscribed(String channelName, User user);
+
+    void onEventWithMetadata(String channelName, String eventName, String data, EventMetadata metadata);
 }

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -23,6 +23,11 @@ public class ChannelImpl implements InternalChannel {
     private final Map<String, Set<SubscriptionEventListener>> eventNameToListenerMap = new HashMap<String, Set<SubscriptionEventListener>>();
     protected volatile ChannelState state = ChannelState.INITIAL;
     private ChannelEventListener eventListener;
+
+    protected Factory getFactory() {
+        return factory;
+    }
+
     private final Factory factory;
     private final Object lock = new Object();
 
@@ -190,7 +195,7 @@ public class ChannelImpl implements InternalChannel {
     }
 
     @SuppressWarnings("unchecked")
-    private String extractDataFrom(final String message) {
+    protected String extractDataFrom(final String message) {
         final Map<Object, Object> jsonObject = GSON.fromJson(message, Map.class);
         return (String)jsonObject.get("data");
     }
@@ -199,7 +204,7 @@ public class ChannelImpl implements InternalChannel {
         return new String[] { "^private-.*", "^presence-.*" };
     }
 
-    private void validateArguments(final String eventName, final SubscriptionEventListener listener) {
+    protected void validateArguments(final String eventName, final SubscriptionEventListener listener) {
 
         if (eventName == null) {
             throw new IllegalArgumentException("Cannot bind or unbind to channel " + name + " with a null event name");

--- a/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
@@ -34,7 +34,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
     private String myUserID;
 
     public PresenceChannelImpl(final InternalConnection connection, final String channelName,
-            final Authorizer authorizer, final Factory factory) {
+                               final Authorizer authorizer, final Factory factory) {
         super(connection, channelName, authorizer, factory);
     }
 
@@ -87,9 +87,13 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
                         getFactory().queueOnEventThread(new Runnable() {
                         @Override
                         public void run() {
-                            listener.onEvent(name, event, data);
+                            if (event.startsWith(CLIENT_EVENT_PREFIX)) {
+                                listener.onEventWithMetadata(name, event, data, metadata);
+                            }
+                            else {
+                                listener.onEvent(name, event, data);
+                            }
 
-                            listener.onEventWithMetadata(name, event, data, metadata);
                         }
                     });
                 }
@@ -116,7 +120,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
 
         try {
             final Map authResponseMap = GSON.fromJson(authResponse, Map.class);
-            final String authKey = (String)authResponseMap.get("auth");
+            final String authKey = (String) authResponseMap.get("auth");
             final Object channelData = authResponseMap.get("channel_data");
 
             storeMyUserId(channelData);
@@ -134,8 +138,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
             final String json = GSON.toJson(jsonObject);
 
             return json;
-        }
-        catch (final Exception e) {
+        } catch (final Exception e) {
             throw new AuthorizationFailureException("Unable to parse response from Authorizer: " + authResponse, e);
         }
     }
@@ -180,7 +183,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
 
     @Override
     protected String[] getDisallowedNameExpressions() {
-        return new String[] { "^(?!presence-).*" };
+        return new String[]{"^(?!presence-).*"};
     }
 
     @Override
@@ -188,7 +191,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
         return String.format("[Presence Channel: name=%s]", name);
     }
 
-    @SuppressWarnings({ "rawtypes", "unchecked" })
+    @SuppressWarnings({"rawtypes", "unchecked"})
     private void handleSubscriptionSuccessfulMessage(final String message) {
 
         // extract data from the JSON message
@@ -206,7 +209,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
         }
         final ChannelEventListener listener = getEventListener();
         if (listener != null) {
-            final PresenceChannelEventListener presenceListener = (PresenceChannelEventListener)listener;
+            final PresenceChannelEventListener presenceListener = (PresenceChannelEventListener) listener;
             presenceListener.onUsersInformationReceived(getName(), getUsers());
         }
     }
@@ -218,14 +221,14 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
 
 
         final String id = memberData.userId;
-        final String userData = memberData.userInfo!= null ? GSON.toJson(memberData.userInfo) : null;
+        final String userData = memberData.userInfo != null ? GSON.toJson(memberData.userInfo) : null;
 
         final User user = new User(id, userData);
         idToUserMap.put(id, user);
 
         final ChannelEventListener listener = getEventListener();
         if (listener != null) {
-            final PresenceChannelEventListener presenceListener = (PresenceChannelEventListener)listener;
+            final PresenceChannelEventListener presenceListener = (PresenceChannelEventListener) listener;
             presenceListener.userSubscribed(getName(), user);
         }
     }
@@ -240,7 +243,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
 
         final ChannelEventListener listener = getEventListener();
         if (listener != null) {
-            final PresenceChannelEventListener presenceListener = (PresenceChannelEventListener)listener;
+            final PresenceChannelEventListener presenceListener = (PresenceChannelEventListener) listener;
             presenceListener.userUnsubscribed(getName(), user);
         }
     }
@@ -264,7 +267,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
 
     @SuppressWarnings("rawtypes")
     private void storeMyUserId(final Object channelData) {
-        final Map channelDataMap = GSON.fromJson((String)channelData, Map.class);
+        final Map channelDataMap = GSON.fromJson((String) channelData, Map.class);
         myUserID = String.valueOf(channelDataMap.get("user_id"));
     }
 

--- a/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
@@ -19,7 +19,7 @@ import com.pusher.client.util.Factory;
 public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
 
     private static final Gson GSON = new Gson();
-    private static final String CLIENT_EVENT_PREFIX = "client-";
+    protected static final String CLIENT_EVENT_PREFIX = "client-";
     private final InternalConnection connection;
     private final Authorizer authorizer;
 

--- a/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
@@ -4,6 +4,7 @@ import java.util.Set;
 
 import com.pusher.client.Pusher;
 import com.pusher.client.PusherOptions;
+import com.pusher.client.channel.EventMetadata;
 import com.pusher.client.channel.PresenceChannel;
 import com.pusher.client.channel.PresenceChannelEventListener;
 import com.pusher.client.channel.User;
@@ -97,6 +98,13 @@ public class PresenceChannelExampleApp implements ConnectionEventListener, Prese
 
         System.out.println(String.format("Received event [%s] on channel [%s] with data [%s]", eventName, channelName,
                 data));
+    }
+
+    @Override
+    public void onEventWithMetadata(final String channelName, final String eventName, final String data, final EventMetadata metadata) {
+
+        System.out.println(String.format("Received event [%s] on channel [%s] with data [%s] with metadata user_id: [%s]", eventName, channelName,
+                data, metadata.getUserId()));
     }
 
     @Override


### PR DESCRIPTION
## Description of the pull request

The `message` json for client-events coming from the `pusher-server` has an additional parameter `metadata` with user-id. This PR adds support for the `user-id` feature.

## How it’s implemented in pusher-js
In pusher-js library for client-events on presence channels callbacks will be called with an additional argument. This argument is a hash with the user_id field: https://github.com/pusher/pusher-js#bind-and-unbind

## Why you can’t do the same in pusher-websocket-java
I didn’t find a way to achieve the same implementation in `pusher-websocket-java`. The obstacle is the inheritance tree.
```
                SubscriptionEventListener
                                  ↓
                ChannelEventListener
                                  ↓
                PrivateChannelEventListener
                                  ↓
                PresenceChannelEventListener
```
When you’re binding to `onEvent` you create an Object of one of the listener’s type. `onEvent` method is implemented on the first level of hierarchy. You can’t override this method in `PresenceChannelEventListener` but [with the different number of arguments](https://stackoverflow.com/questions/10572643/optional-methods-in-java-interface).

## Solution
Create a new method `onEventWithMetadata(String channelName, String eventName, String data, Metadata metadata)` 

 **Pros**:
 – We do not force into application any new instances from the outside of the current tree.
– It is implemented the same way as other methods in the Listeners interfaces and we keep the context consistent.
 – It doesn’t break any current implemented functionality in customers apps with only public and private changes.

**Cons**:
– There are no optional methods in interfaces in Java. The Java language requires that every method in an interface is implemented by every implementation of that interface. If the customer app uses Presence Channels and doesn’t use `client-events` they need to extend a `new PresenceChannelEventListener` section  with an empty method `onEventWithMetadata`.
– It will break all applications that use Presence Channels.

---
## Checklist
[x] All new functionality has tests.
[x] All tests are passing.
[] New or changed API methods have been documented.

CC @pusher/mobile 
