### PR TITLE
Switch back to non-forked version of java-websocket

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ repositories {
 
 dependencies {
 	compile "com.google.code.gson:gson:2.2.2"
-	compile "com.pusher:java-websocket:1.4.1"
+	compile "org.java-websocket:Java-WebSocket:1.4.0"
 	testCompile "org.mockito:mockito-all:1.8.5"
 	testCompile "org.powermock:powermock-module-junit4:1.4.11"
 	testCompile "org.powermock:powermock-api-mockito:1.4.11"

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketClientWrapper.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketClientWrapper.java
@@ -10,8 +10,8 @@ import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSocketFactory;
 
-import com.pusher.java_websocket.client.WebSocketClient;
-import com.pusher.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
 
 /**
  * A thin wrapper around the WebSocketClient class from the Java-WebSocket

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -14,7 +14,7 @@ import java.util.logging.Logger;
 
 import javax.net.ssl.SSLException;
 
-import com.pusher.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.handshake.ServerHandshake;
 
 import com.google.gson.Gson;
 

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketListener.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketListener.java
@@ -1,6 +1,6 @@
 package com.pusher.client.connection.websocket;
 
-import com.pusher.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.handshake.ServerHandshake;
 
 public interface WebSocketListener {
 

--- a/src/main/java/com/pusher/client/example/SimpleWebSocket.java
+++ b/src/main/java/com/pusher/client/example/SimpleWebSocket.java
@@ -3,8 +3,8 @@ package com.pusher.client.example;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import com.pusher.java_websocket.client.WebSocketClient;
-import com.pusher.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
 
 public class SimpleWebSocket extends WebSocketClient {
     public static void main(final String[] args) throws URISyntaxException {

--- a/src/test/java/com/pusher/client/EndToEndTest.java
+++ b/src/test/java/com/pusher/client/EndToEndTest.java
@@ -31,7 +31,7 @@ import com.pusher.client.connection.websocket.WebSocketConnection;
 import com.pusher.client.connection.websocket.WebSocketListener;
 import com.pusher.client.util.DoNothingExecutor;
 import com.pusher.client.util.Factory;
-import com.pusher.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.handshake.ServerHandshake;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EndToEndTest {

--- a/src/test/java/com/pusher/client/connection/websocket/WebSocketClientWrapperTest.java
+++ b/src/test/java/com/pusher/client/connection/websocket/WebSocketClientWrapperTest.java
@@ -8,7 +8,7 @@ import java.net.URISyntaxException;
 
 import javax.net.ssl.SSLException;
 
-import com.pusher.java_websocket.handshake.ServerHandshake;
+import org.java_websocket.handshake.ServerHandshake;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
### Description of the pull request

In https://github.com/pusher/pusher-websocket-java/commit/569b765e5955842b7fac699a07c11ee6c9c04a38, we switched from using https://github.com/TooTallNate/Java-WebSocket to a fork https://github.com/pusher/java-websocket because the original was not actively maintained.

I've manually tested the change in an Android app.

#### Why is the change necessary?

https://github.com/TooTallNate/Java-WebSocket is now actively maintained again. We'd rather not maintain a fork.

----

CC @pusher/mobile 
