### PR TITLE
Downgrade gradle to 5.0

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
The combination of this gradle version, the signing plugin and the
legacy maven plugin seem to cause the error:

Execution failed for task ':signArchives'.
Duplicate key pusher-websocket-java:jar.asc:asc: (attempted merging values Signature pusher-websocket-java:jar.asc:asc: and Signature pusher-websocket-java:jar.asc:asc:)

There is not much information about this online, except for

https://github.com/gradle/gradle/issues/8213 and
https://discuss.gradle.org/t/apply-plugin-signing-broke-in-gradle-5-1-1-and-prints-out-non-existent-task/31418

Switching to the recommended maven plugin `maven-publish` might
solve this problem, but that will be more work, so downgrading
gradle is a better option in the short term.

----

CC @pusher/mobile 
