### PR TITLE
Forward channel data on private channels

### DIFF
--- a/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
@@ -2,7 +2,6 @@ package com.pusher.client.channel.impl;
 
 import com.google.gson.Gson;
 import com.google.gson.annotations.SerializedName;
-import com.pusher.client.AuthorizationFailureException;
 import com.pusher.client.Authorizer;
 import com.pusher.client.channel.ChannelEventListener;
 import com.pusher.client.channel.PresenceChannel;
@@ -65,35 +64,10 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
     }
 
     @Override
-    @SuppressWarnings("rawtypes")
     public String toSubscribeMessage() {
-
-        final String authResponse = getAuthResponse();
-
-        try {
-            final Map authResponseMap = GSON.fromJson(authResponse, Map.class);
-            final String authKey = (String)authResponseMap.get("auth");
-            final Object channelData = authResponseMap.get("channel_data");
-
-            storeMyUserId(channelData);
-
-            final Map<Object, Object> jsonObject = new LinkedHashMap<Object, Object>();
-            jsonObject.put("event", "pusher:subscribe");
-
-            final Map<Object, Object> dataMap = new LinkedHashMap<Object, Object>();
-            dataMap.put("channel", name);
-            dataMap.put("auth", authKey);
-            dataMap.put("channel_data", channelData);
-
-            jsonObject.put("data", dataMap);
-
-            final String json = GSON.toJson(jsonObject);
-
-            return json;
-        }
-        catch (final Exception e) {
-            throw new AuthorizationFailureException("Unable to parse response from Authorizer: " + authResponse, e);
-        }
+        String msg = super.toSubscribeMessage();
+        storeMyUserId(channelData);
+        return msg;
     }
 
     @Override

--- a/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
@@ -68,7 +68,7 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
     @Override
     public String toSubscribeMessage() {
         String msg = super.toSubscribeMessage();
-        myUserID = extractUserIdFromChannelData((String)channelData);
+        myUserID = extractUserIdFromChannelData(channelData);
         return msg;
     }
 

--- a/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
@@ -23,6 +23,8 @@ public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
     private final InternalConnection connection;
     private final Authorizer authorizer;
 
+    protected String channelData;
+
     public PrivateChannelImpl(final InternalConnection connection, final String channelName,
             final Authorizer authorizer, final Factory factory) {
         super(channelName, factory);
@@ -90,6 +92,7 @@ public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
         try {
             final Map authResponseMap = GSON.fromJson(authResponse, Map.class);
             final String authKey = (String)authResponseMap.get("auth");
+            channelData = (String)authResponseMap.get("channel_data");
 
             final Map<Object, Object> jsonObject = new LinkedHashMap<Object, Object>();
             jsonObject.put("event", "pusher:subscribe");
@@ -97,6 +100,9 @@ public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
             final Map<Object, Object> dataMap = new LinkedHashMap<Object, Object>();
             dataMap.put("channel", name);
             dataMap.put("auth", authKey);
+            if (channelData != null) {
+                dataMap.put("channel_data", channelData);
+            }
 
             jsonObject.put("data", dataMap);
 

--- a/src/test/java/com/pusher/client/channel/impl/PresenceChannelImplTest.java
+++ b/src/test/java/com/pusher/client/channel/impl/PresenceChannelImplTest.java
@@ -27,7 +27,7 @@ import com.pusher.client.channel.User;
 @RunWith(MockitoJUnitRunner.class)
 public class PresenceChannelImplTest extends PrivateChannelImplTest {
 
-    private static final String AUTH_RESPONSE = "\"auth\":\"a87fe72c6f36272aa4b1:f9db294eae7\",\"channel_data\":\"{\\\"user_id\\\":\\\"51169fc47abac\\\",\\\"user_info\\\":{\\\"name\\\":\\\"Phil Leggetter\\\",\\\"twitter_id\\\":\\\"@leggetter\\\"}}\"";
+    private static final String AUTH_RESPONSE = "\"auth\":\"a87fe72c6f36272aa4b1:f9db294eae7\",\"channel_data\":\"{\\\"user_id\\\":\\\"5116a4519575b\\\",\\\"user_info\\\":{\\\"name\\\":\\\"Phil Leggetter\\\",\\\"twitter_id\\\":\\\"@leggetter\\\"}}\"";
     private static final String AUTH_RESPONSE_NUMERIC_ID = "\"auth\":\"a87fe72c6f36272aa4b1:f9db294eae7\",\"channel_data\":\"{\\\"user_id\\\":51169,\\\"user_info\\\":{\\\"name\\\":\\\"Phil Leggetter\\\",\\\"twitter_id\\\":\\\"@leggetter\\\"}}\"";
     private static final String USER_ID = "5116a4519575b";
 
@@ -58,6 +58,14 @@ public class PresenceChannelImplTest extends PrivateChannelImplTest {
         final String message = channel.toSubscribeMessage();
         assertEquals("{\"event\":\"pusher:subscribe\",\"data\":{\"channel\":\"" + getChannelName() + "\","
                 + AUTH_RESPONSE_NUMERIC_ID + "}}", message);
+    }
+
+    @Test
+    public void testStoresCorrectUser() {
+        channel.toSubscribeMessage();
+        channel.onMessage("pusher_internal:subscription_succeeded",
+        "{\"event\":\"pusher_internal:subscription_succeeded\",\"data\":\"{\\\"presence\\\":{\\\"count\\\":1,\\\"ids\\\":[\\\"5116a4519575b\\\"],\\\"hash\\\":{\\\"5116a4519575b\\\":{\\\"name\\\":\\\"Phil Leggetter\\\",\\\"twitter_id\\\":\\\"@leggetter\\\"}}}}\",\"channel\":\"presence-myChannel\"}");
+        assertEquals(USER_ID, ((PresenceChannelImpl)channel).getMe().getId());
     }
 
     @Override

--- a/src/test/java/com/pusher/client/channel/impl/PrivateChannelImplTest.java
+++ b/src/test/java/com/pusher/client/channel/impl/PrivateChannelImplTest.java
@@ -21,7 +21,8 @@ import com.pusher.client.connection.impl.InternalConnection;
 @RunWith(MockitoJUnitRunner.class)
 public class PrivateChannelImplTest extends ChannelImplTest {
 
-    private static final String AUTH_TOKEN = "\"auth\":\"a87fe72c6f36272aa4b1:41dce43734b18bb\"";
+    private static final String AUTH_RESPONSE = "\"auth\":\"a87fe72c6f36272aa4b1:41dce43734b18bb\"";
+    private static final String AUTH_RESPONSE_WITH_CHANNEL_DATA = "\"auth\":\"a87fe72c6f36272aa4b1:41dce43734b18bb\",\"channel_data\":\"{\\\"user_id\\\":\\\"51169fc47abac\\\"}\"";
 
     @Mock
     protected InternalConnection mockConnection;
@@ -32,7 +33,7 @@ public class PrivateChannelImplTest extends ChannelImplTest {
     @Before
     public void setUp() {
         super.setUp();
-        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("{" + AUTH_TOKEN + "}");
+        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("{" + AUTH_RESPONSE + "}");
     }
 
     @Test
@@ -72,7 +73,16 @@ public class PrivateChannelImplTest extends ChannelImplTest {
     @Test
     @Override
     public void testReturnsCorrectSubscribeMessage() {
-        assertEquals("{\"event\":\"pusher:subscribe\",\"data\":{\"channel\":\"" + getChannelName() + "\"," + AUTH_TOKEN
+        assertEquals("{\"event\":\"pusher:subscribe\",\"data\":{\"channel\":\"" + getChannelName() + "\"," + AUTH_RESPONSE
+                + "}}", channel.toSubscribeMessage());
+    }
+
+    @Test
+    public void testReturnsCorrectSubscribeMessageWithChannelData() {
+        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn(
+                "{" + AUTH_RESPONSE_WITH_CHANNEL_DATA + "}");
+
+        assertEquals("{\"event\":\"pusher:subscribe\",\"data\":{\"channel\":\"" + getChannelName() + "\"," + AUTH_RESPONSE_WITH_CHANNEL_DATA
                 + "}}", channel.toSubscribeMessage());
     }
 


### PR DESCRIPTION
If the auth endpoint returns channel_data, then this should be
forwarded to the auth endpoint even if it is not used by private
channels currently.

This is useful because it allows the same auth endpoint to be
used for private and presence channels.

It also avoids confusing auth signature errors that occur when the
channel_data is not sent (but the auth signature was computed from
it).

Fixes #144.

In order to support the getMe() method on PresenceChannel, we need
to store the channel_data in the PrivateChannelImpl class. This
is decoded in the PresenceChannelImpl class since presence channels
require the channel_data is JSON. It is decoded in toSubscribeMessage()
rather than getMe() to preserve the original semantics (e.g.
exceptions cannot be thrown from getMe().

----

CC @pusher/mobile 
