### PR TITLE
Make a no-op state change non-fatal

### DIFF
--- a/src/main/java/com/pusher/client/connection/ConnectionStateChange.java
+++ b/src/main/java/com/pusher/client/connection/ConnectionStateChange.java
@@ -1,10 +1,13 @@
 package com.pusher.client.connection;
 
+import java.util.logging.Logger;
+
 /**
  * Represents a change in connection state.
  */
 public class ConnectionStateChange {
 
+    private static final Logger log = Logger.getLogger(ConnectionStateChange.class.getName());
     private final ConnectionState previousState;
     private final ConnectionState currentState;
 
@@ -18,9 +21,8 @@ public class ConnectionStateChange {
     public ConnectionStateChange(final ConnectionState previousState, final ConnectionState currentState) {
 
         if (previousState == currentState) {
-            throw new IllegalArgumentException(
-                    "Attempted to create an connection state update where both previous and current state are: "
-                            + currentState);
+	    log.fine("Attempted to create an connection state update where both previous and current state are: "
+		     + currentState);
         }
 
         this.previousState = previousState;

--- a/src/test/java/com/pusher/client/connection/ConnectionStateChangeTest.java
+++ b/src/test/java/com/pusher/client/connection/ConnectionStateChangeTest.java
@@ -20,11 +20,6 @@ public class ConnectionStateChangeTest {
         assertSame(current, change.getCurrentState());
     }
 
-    @Test(expected = IllegalArgumentException.class)
-    public void testFailFastIfPreviousStateIsSameAsCurrentState() {
-        new ConnectionStateChange(ConnectionState.CONNECTED, ConnectionState.CONNECTED);
-    }
-
     @Test
     public void testHashCodeAndEquals() {
         final ConnectionStateChange instanceOne = new ConnectionStateChange(ConnectionState.DISCONNECTED,


### PR DESCRIPTION
### Description of the pull request

We currently fail hard when a state update to the current state is requested.  This change simply logs the error instead, for debugging.

#### Why is the change necessary?

There are clearly situations where this _can_ happen (issue #218) and is more likely to happen on newer devices (assuming there's a race condition). 

