### PR TITLE
CI codecov reports

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,6 @@ jdk:
 script:
   - ./gradlew jacocoTestReport test
 
-  after_success:
-  # report coverage
-  - bash <(curl -s https://codecov.io/bash)
+after_success:
+# report coverage
+- bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,8 @@ jdk:
   - openjdk10
   - openjdk11
 script:
-  - ./gradlew test
+  - ./gradlew jacocoTestReport test
+
+  after_success:
+  # report coverage
+  - bash <(curl -s https://codecov.io/bash)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pusher Channels Java Client
 
 [![Build Status](https://travis-ci.org/pusher/pusher-websocket-java.svg?branch=master)](https://travis-ci.org/pusher/pusher-websocket-java)
+[![codecov](https://codecov.io/gh/pusher/pusher-websocket-java/branch/master/graph/badge.svg)](https://codecov.io/gh/pusher/pusher-websocket-java)
 
 Pusher Channels client library for Java targeting **Android** and general Java.
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ apply plugin: 'maven'
 apply plugin: 'eclipse'
 apply plugin: 'org.ajoberstar.github-pages'
 apply plugin: 'signing'
+apply plugin: 'jacoco'
 
 group = "com.pusher"
 version = "2.0.2"
@@ -185,4 +186,14 @@ task createPublishTarget {
 
 wrapper {
 	gradleVersion = '5.5.1'
+}
+
+jacoco {
+	toolVersion = "0.8.4"
+}
+
+jacocoTestReport {
+	reports.xml.enabled = true
+	reports.html.enabled = false
+	reports.csv.enabled = false
 }


### PR DESCRIPTION
### What
Added Jacoco plugin to generate test reports. 
Updated the travis.yml to generate the tests and send them to codecov.
...

#### Why
This enables codecov to post in PRs to let us know if we're increasing or decreasing code coverage at all (hopefully)
...
