### PR TITLE
Exclude Base64 class from Javadoc

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,12 +66,13 @@ javadoc {
 	options.overview = file("src/main/javadoc/overview.html")
 	// uncomment this to use the custom javadoc styles
 	//options.stylesheetFile = file("src/main/javadoc/css/styles.css")
-	exclude "**/com/pusher/client/channel/impl/*"
-	exclude "**/com/pusher/client/connection/impl/*"
-	exclude "**/com/pusher/client/connection/websocket/*"
-	exclude "**/com/pusher/client/crypto/nacl/*"
-	exclude "**/org/java_websocket/*"
-	exclude "**/com/pusher/client/example/*"
+	exclude "com/pusher/client/channel/impl/*"
+	exclude "com/pusher/client/connection/impl/*"
+	exclude "com/pusher/client/connection/websocket/*"
+	exclude "com/pusher/client/crypto/nacl/*"
+	exclude "com/pusher/client/util/internal/*"
+	exclude "org/java_websocket/*"
+	exclude "com/pusher/client/example/*"
 	options.linkSource = true
 }
 

--- a/src/main/java/com/pusher/client/util/internal/Base64.java
+++ b/src/main/java/com/pusher/client/util/internal/Base64.java
@@ -1,4 +1,4 @@
-package com.pusher.client.util;
+package com.pusher.client.util.internal;
 
 import static java.util.Arrays.fill;
 

--- a/src/test/java/com/pusher/client/crypto/nacl/SecretBoxOpenerTest.java
+++ b/src/test/java/com/pusher/client/crypto/nacl/SecretBoxOpenerTest.java
@@ -2,7 +2,7 @@ package com.pusher.client.crypto.nacl;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.pusher.client.util.Base64;
+import com.pusher.client.util.internal.Base64;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/com/pusher/client/util/Base64Test.java
+++ b/src/test/java/com/pusher/client/util/Base64Test.java
@@ -2,6 +2,7 @@ package com.pusher.client.util;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.pusher.client.util.internal.Base64;
 import org.junit.Test;
 
 public class Base64Test {


### PR DESCRIPTION
Simplify exclude rules making it more clear they refer
to package names not file paths relative to project's root.

CC @pusher/mobile 
