### PR TITLE
Dev decrypt plus retry

### DIFF
--- a/src/main/java/com/pusher/client/channel/PrivateEncryptedChannelEventListener.java
+++ b/src/main/java/com/pusher/client/channel/PrivateEncryptedChannelEventListener.java
@@ -6,5 +6,5 @@ package com.pusher.client.channel;
  */
 public interface PrivateEncryptedChannelEventListener extends PrivateChannelEventListener {
 
-    void onDecryptionFailure(Exception e);
+    void onDecryptionFailure(String event, String reason);
 }

--- a/src/main/java/com/pusher/client/channel/PrivateEncryptedChannelEventListener.java
+++ b/src/main/java/com/pusher/client/channel/PrivateEncryptedChannelEventListener.java
@@ -6,5 +6,5 @@ package com.pusher.client.channel;
  */
 public interface PrivateEncryptedChannelEventListener extends PrivateChannelEventListener {
 
-    //  TODO: add onDecryptionFailure
+    void onDecryptionFailure(Exception e);
 }

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -211,15 +211,8 @@ public class ChannelImpl implements InternalChannel {
     }
 
     protected Set<SubscriptionEventListener> getInterestedListeners(String event) {
-        final Set<SubscriptionEventListener> listeners;
         synchronized (lock) {
-            final Set<SubscriptionEventListener> sharedListeners = eventNameToListenerMap.get(event);
-            if (sharedListeners != null) {
-                listeners = new HashSet<SubscriptionEventListener>(sharedListeners);
-            } else {
-                listeners = null;
-            }
+            return eventNameToListenerMap.get(event);
         }
-        return listeners;
     }
 }

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -212,7 +212,15 @@ public class ChannelImpl implements InternalChannel {
 
     protected Set<SubscriptionEventListener> getInterestedListeners(String event) {
         synchronized (lock) {
-            return eventNameToListenerMap.get(event);
+
+            final Set<SubscriptionEventListener> sharedListeners =
+                    eventNameToListenerMap.get(event);
+
+            if (sharedListeners == null) {
+                return null;
+            }
+
+            return new HashSet<>(sharedListeners);
         }
     }
 }

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -99,19 +99,8 @@ public class ChannelImpl implements InternalChannel {
 
         if (event.equals(SUBSCRIPTION_SUCCESS_EVENT)) {
             updateState(ChannelState.SUBSCRIBED);
-        }
-        else {
-            final Set<SubscriptionEventListener> listeners;
-            synchronized (lock) {
-                final Set<SubscriptionEventListener> sharedListeners = eventNameToListenerMap.get(event);
-                if (sharedListeners != null) {
-                    listeners = new HashSet<SubscriptionEventListener>(sharedListeners);
-                }
-                else {
-                    listeners = null;
-                }
-            }
-
+        } else {
+            final Set<SubscriptionEventListener> listeners = getInterestedListeners(event);
             if (listeners != null) {
                 final PusherEvent pusherEvent = prepareEvent(event, message);
                 if (pusherEvent != null) {
@@ -219,5 +208,18 @@ public class ChannelImpl implements InternalChannel {
             throw new IllegalStateException(
                     "Cannot bind or unbind to events on a channel that has been unsubscribed. Call Pusher.subscribe() to resubscribe to this channel");
         }
+    }
+
+    protected Set<SubscriptionEventListener> getInterestedListeners(String event) {
+        final Set<SubscriptionEventListener> listeners;
+        synchronized (lock) {
+            final Set<SubscriptionEventListener> sharedListeners = eventNameToListenerMap.get(event);
+            if (sharedListeners != null) {
+                listeners = new HashSet<SubscriptionEventListener>(sharedListeners);
+            } else {
+                listeners = null;
+            }
+        }
+        return listeners;
     }
 }

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -90,6 +90,11 @@ public class ChannelImpl implements InternalChannel {
     /* InternalChannel implementation */
 
     @Override
+    public PusherEvent prepareEvent(String event, String message) {
+        return GSON.fromJson(message, PusherEvent.class);
+    }
+
+    @Override
     public void onMessage(final String event, final String message) {
 
         if (event.equals(SUBSCRIPTION_SUCCESS_EVENT)) {
@@ -108,14 +113,16 @@ public class ChannelImpl implements InternalChannel {
             }
 
             if (listeners != null) {
-                for (final SubscriptionEventListener listener : listeners) {
-                    final PusherEvent e = GSON.fromJson(message, PusherEvent.class);
-                    factory.queueOnEventThread(new Runnable() {
-                        @Override
-                        public void run() {
-                            listener.onEvent(e);
-                        }
-                    });
+                final PusherEvent pusherEvent = prepareEvent(event, message);
+                if (pusherEvent != null) {
+                    for (final SubscriptionEventListener listener : listeners) {
+                        factory.queueOnEventThread(new Runnable() {
+                            @Override
+                            public void run() {
+                                listener.onEvent(pusherEvent);
+                            }
+                        });
+                    }
                 }
             }
         }

--- a/src/main/java/com/pusher/client/channel/impl/InternalChannel.java
+++ b/src/main/java/com/pusher/client/channel/impl/InternalChannel.java
@@ -3,12 +3,15 @@ package com.pusher.client.channel.impl;
 import com.pusher.client.channel.Channel;
 import com.pusher.client.channel.ChannelEventListener;
 import com.pusher.client.channel.ChannelState;
+import com.pusher.client.channel.PusherEvent;
 
 public interface InternalChannel extends Channel, Comparable<InternalChannel> {
 
     String toSubscribeMessage();
 
     String toUnsubscribeMessage();
+
+    PusherEvent prepareEvent(String event, String message);
 
     void onMessage(String event, String message);
 

--- a/src/main/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImpl.java
@@ -138,23 +138,18 @@ public class PrivateEncryptedChannelImpl extends ChannelImpl implements PrivateE
                 return decryptMessage(message);
             } catch (AuthenticityException e1) {
 
-                retryDecryptingMessage(event, message);
+                // retry once only.
+                disposeSecretBoxOpener();
+                authenticate();
+
+                try {
+                    return decryptMessage(message);
+                } catch (AuthenticityException e2) {
+                    disposeSecretBoxOpener();
+                    notifyListenersOfDecryptFailure(event, "Failed to decrypt message.");
+                }
             }
 
-        }
-        return null;
-    }
-
-    private PusherEvent retryDecryptingMessage(String event, String message) {
-
-        disposeSecretBoxOpener();
-        authenticate();
-
-        try {
-            return decryptMessage(message);
-        } catch (AuthenticityException e2) {
-            disposeSecretBoxOpener();
-            notifyListenersOfDecryptFailure(event, "Failed to decrypt message.");
         }
         return null;
     }

--- a/src/main/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImpl.java
@@ -136,12 +136,12 @@ public class PrivateEncryptedChannelImpl extends ChannelImpl implements PrivateE
 
             try {
 
-                Map receivedMessage = GSON.fromJson(message, Map.class);
+                Map<String, Object> receivedMessage =
+                        GSON.<Map<String, Object>>fromJson(message, Map.class);
                 final String decryptedMessage = decryptMessage((String) receivedMessage.get("data"));
                 receivedMessage.replace("data", decryptedMessage);
 
-                return GSON.fromJson(
-                        GSON.toJson(receivedMessage), PusherEvent.class);
+                return new PusherEvent(receivedMessage);
 
             } catch (AuthenticityException e1) {
 
@@ -150,12 +150,12 @@ public class PrivateEncryptedChannelImpl extends ChannelImpl implements PrivateE
                 authenticate();
 
                 try {
-                    Map receivedMessage = GSON.fromJson(message, Map.class);
+                    Map<String, Object> receivedMessage =
+                            GSON.<Map<String, Object>>fromJson(message, Map.class);
                     final String decryptedMessage = decryptMessage((String) receivedMessage.get("data"));
                     receivedMessage.replace("data", decryptedMessage);
 
-                    return GSON.fromJson(
-                            GSON.toJson(receivedMessage), PusherEvent.class);
+                    return new PusherEvent(receivedMessage);
                 } catch (AuthenticityException e2) {
                     disposeSecretBoxOpener();
                     notifyListenersOfDecryptFailure(event, "Failed to decrypt message.");

--- a/src/main/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImpl.java
@@ -17,7 +17,6 @@ import com.pusher.client.crypto.nacl.SecretBoxOpenerFactory;
 import com.pusher.client.util.Factory;
 import com.pusher.client.util.internal.Base64;
 
-import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Set;

--- a/src/main/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImpl.java
@@ -138,18 +138,23 @@ public class PrivateEncryptedChannelImpl extends ChannelImpl implements PrivateE
                 return decryptMessage(message);
             } catch (AuthenticityException e1) {
 
-                // retry once only.
-                disposeSecretBoxOpener();
-                authenticate();
-
-                try {
-                    return decryptMessage(message);
-                } catch (AuthenticityException e2) {
-                    disposeSecretBoxOpener();
-                    notifyListenersOfDecryptFailure(event, "Failed to decrypt message.");
-                }
+                retryDecryptingMessage(event, message);
             }
 
+        }
+        return null;
+    }
+
+    private PusherEvent retryDecryptingMessage(String event, String message) {
+
+        disposeSecretBoxOpener();
+        authenticate();
+
+        try {
+            return decryptMessage(message);
+        } catch (AuthenticityException e2) {
+            disposeSecretBoxOpener();
+            notifyListenersOfDecryptFailure(event, "Failed to decrypt message.");
         }
         return null;
     }

--- a/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
@@ -88,8 +88,8 @@ public class PrivateEncryptedChannelExampleApp implements
     }
 
     @Override
-    public void onDecryptionFailure(Exception e) {
+    public void onDecryptionFailure(String event, String reason) {
         System.out.println(String.format(
-                "An error was received decrypting message - exception: [%s]", e));
+                "An error was received decrypting message for event:[%s] - reason: [%s]", event, reason));
     }
 }

--- a/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
@@ -86,4 +86,10 @@ public class PrivateEncryptedChannelExampleApp implements
                 code,
                 e));
     }
+
+    @Override
+    public void onDecryptionFailure(Exception e) {
+        System.out.println(String.format(
+                "An error was received decrypting message - exception: [%s]", e));
+    }
 }

--- a/src/test/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImplTest.java
+++ b/src/test/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImplTest.java
@@ -1,9 +1,12 @@
 package com.pusher.client.channel.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.pusher.client.AuthorizationFailureException;
@@ -11,7 +14,10 @@ import com.pusher.client.Authorizer;
 import com.pusher.client.channel.ChannelEventListener;
 import com.pusher.client.channel.PrivateEncryptedChannelEventListener;
 import com.pusher.client.connection.impl.InternalConnection;
+import com.pusher.client.crypto.nacl.SecretBoxOpener;
 import com.pusher.client.crypto.nacl.SecretBoxOpenerFactory;
+import com.pusher.client.util.internal.Base64;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,6 +32,7 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
     final String AUTH_RESPONSE_MISSING_AUTH = "{\"shared_secret\":\"iBvNoPVYwByqSfg6anjPpEQ2j051b3rt1Vmnb+z5doo=\"}";
     final String AUTH_RESPONSE_MISSING_SHARED_SECRET = "{\"auth\":\"636a81ba7e7b15725c00:3ee04892514e8a669dc5d30267221f16727596688894712cad305986e6fc0f3c\"}";
     final String AUTH_RESPONSE_INVALID_JSON = "potatoes";
+    final String SHARED_SECRET = "iBvNoPVYwByqSfg6anjPpEQ2j051b3rt1Vmnb+z5doo=";
 
     @Mock
     InternalConnection mockInternalConnection;
@@ -147,5 +154,72 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
         PrivateEncryptedChannelImpl channel = newInstance();
 
         channel.toSubscribeMessage();
+    }
+
+    /*
+    ON MESSAGE
+     */
+    @Test
+    public void testDataIsExtractedFromMessageAndPassedToSingleListener() {
+        PrivateEncryptedChannelImpl channel = new PrivateEncryptedChannelImpl(
+                mockInternalConnection,
+                getChannelName(),
+                mockAuthorizer,
+                factory,
+                mockSecretBoxOpenerFactory);
+
+        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(AUTH_RESPONSE);
+        when(mockSecretBoxOpenerFactory.create(any()))
+                .thenReturn(new SecretBoxOpener(Base64.decode(SHARED_SECRET)));
+
+        channel.toSubscribeMessage();
+
+        PrivateEncryptedChannelEventListener mockListener = mock(PrivateEncryptedChannelEventListener.class);
+
+        channel.bind("my-event", mockListener);
+        channel.onMessage("my-event", "{\"event\":\"event1\",\"data\":\"{" +
+                "\\\"nonce\\\": \\\"4sVYwy4j/8dCcjyxtPCWyk19GaaViaW9\\\"," +
+                "\\\"ciphertext\\\": \\\"/GMESnFGlbNn01BuBjp31XYa3i9vZsGKR8fgR9EDhXKx3lzGiUD501A=\\\"" +
+                "}\"}");
+
+        verify(mockListener, times(1)).onEvent(argCaptor.capture());
+        assertEquals("event1", argCaptor.getValue().getEventName());
+        assertEquals("{\"message\":\"hello world\"}", argCaptor.getValue().getData());
+    }
+
+    @Test
+    public void testDataIsExtractedFromMessageAndPassedToMultipleListeners() {
+        PrivateEncryptedChannelImpl channel = new PrivateEncryptedChannelImpl(
+                mockInternalConnection,
+                getChannelName(),
+                mockAuthorizer,
+                factory,
+                mockSecretBoxOpenerFactory);
+
+        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+                .thenReturn(AUTH_RESPONSE);
+        when(mockSecretBoxOpenerFactory.create(any()))
+                .thenReturn(new SecretBoxOpener(Base64.decode(SHARED_SECRET)));
+
+        channel.toSubscribeMessage();
+
+        PrivateEncryptedChannelEventListener mockListener1 = mock(PrivateEncryptedChannelEventListener.class);
+        PrivateEncryptedChannelEventListener mockListener2 = mock(PrivateEncryptedChannelEventListener.class);
+
+        channel.bind("my-event", mockListener1);
+        channel.bind("my-event", mockListener2);
+        channel.onMessage("my-event", "{\"event\":\"event1\",\"data\":\"{" +
+                "\\\"nonce\\\": \\\"4sVYwy4j/8dCcjyxtPCWyk19GaaViaW9\\\"," +
+                "\\\"ciphertext\\\": \\\"/GMESnFGlbNn01BuBjp31XYa3i9vZsGKR8fgR9EDhXKx3lzGiUD501A=\\\"" +
+                "}\"}");
+
+        verify(mockListener1).onEvent(argCaptor.capture());
+        assertEquals("event1", argCaptor.getValue().getEventName());
+        assertEquals("{\"message\":\"hello world\"}", argCaptor.getValue().getData());
+
+        verify(mockListener2).onEvent(argCaptor.capture());
+        assertEquals("event1", argCaptor.getValue().getEventName());
+        assertEquals("{\"message\":\"hello world\"}", argCaptor.getValue().getData());
     }
 }


### PR DESCRIPTION
## What
* Decrypts messages - we convert the received data into a `EncryptedReceivedData` object - we then replace the `data` part of the JSON with the decrypted message and pass it back to be packaged as a PusherEvent.
* Retries only once if we can't decrypt it - if we can't decrypt it a second time we notify the listeners of an `onDecryptionFailure` - I have an open Q about what sort of Exception we should be returning here.
* Added a `prepareEvent` method in the base Channel class which converts the json to the PusherEvent class, but this is where we can hook into decrypting it without having to copy all the other logic to handle messages.
* Added a `getInterestedListeners` to get all the interested listeners for an event - we needed this in the ChannelImpl to notify when a message is received, I also needed a hook into these for notifying when failing to decrypt.