### PR TITLE
Do not use the disconnect method to tear down on pong timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # pusher-websocket-java changelog
 
+## Version 2.1.1 - 15th April 2020
+
+* Fix a case where multiple websocket connections could be opened at once
+  if reconnection was triggered by an activity timeout.
+
 ## Version 2.1.0 - 8th April 2020
 
 * Added support for [private encrypted channels](https://pusher.com/docs/channels/using_channels/encrypted-channels)

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The pusher-java-client is available in Maven Central.
     <dependency>
       <groupId>com.pusher</groupId>
       <artifactId>pusher-java-client</artifactId>
-      <version>2.1.0</version>
+      <version>2.1.1</version>
     </dependency>
 </dependencies>
 ```
@@ -70,7 +70,7 @@ The pusher-java-client is available in Maven Central.
 
 ```groovy
 dependencies {
-  compile 'com.pusher:pusher-java-client:2.1.0'
+  compile 'com.pusher:pusher-java-client:2.1.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'signing'
 apply plugin: 'jacoco'
 
 group = "com.pusher"
-version = "2.1.0"
+version = "2.1.1"
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -403,7 +403,7 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
 
                     underlyingConnection.removeWebSocketListener();
 
-                    disconnect();
+                    underlyingConnection.close();
 
                     // Proceed immediately to handle the close
                     // The WebSocketClient will attempt a graceful WebSocket shutdown by exchanging the close frames

--- a/src/test/java/com/pusher/client/connection/websocket/WebSocketConnectionTest.java
+++ b/src/test/java/com/pusher/client/connection/websocket/WebSocketConnectionTest.java
@@ -298,21 +298,13 @@ public class WebSocketConnectionTest {
     }
 
     @Test
-    public void testPongTimeoutResultsInDisconnect() throws InterruptedException {
+    public void testPongTimeoutResultsInClosingConnection() throws InterruptedException {
         when(factory.getTimers()).thenReturn(new ScheduledThreadPoolExecutor(2));
 
         connection.connect();
         connection.onMessage(CONN_ESTABLISHED_EVENT);
 
         verify(mockUnderlyingConnection, timeout((int) (ACTIVITY_TIMEOUT + PONG_TIMEOUT))).close();
-
-        verify(mockEventListener).onConnectionStateChange(
-                new ConnectionStateChange(ConnectionState.CONNECTED, ConnectionState.DISCONNECTING));
-
-        verify(mockEventListener).onConnectionStateChange(
-                new ConnectionStateChange(ConnectionState.DISCONNECTING, ConnectionState.DISCONNECTED));
-
-        assertEquals(ConnectionState.DISCONNECTED, connection.getState());
     }
 
     @Test


### PR DESCRIPTION
The `disconnect` method is public, and tests the current state before
taking action, scheduling this work to happen on the event thread.

However, when a pong times out, the `onClose` is executed immediately,
transitioning in to the reconnecting state before the scheduled
disconnect happens, meaning disconnect fails to take any action and
potentially resulting in the old connection not being torn down.

----

CC @pusher/mobile 
