### PR TITLE
Remove beta label from private encrypted channel docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This README covers the following topics:
 - [Subscribing to channels](#subscribing-to-channels)
 	- [Public channels](#public-channels)
 	- [Private channels](#private-channels)
-	- [Private encrypted channels [BETA]](#private-encrypted-channels)
+	- [Private encrypted channels](#private-encrypted-channels)
 	- [Presence channels](#presence-channels)
 		- [The User object](#the-user-object)
 - [Binding and handling events](#binding-and-handling-events)
@@ -273,7 +273,7 @@ PrivateChannel channel = pusher.subscribePrivate("private-channel",
     });
 ```
 
-### Private encrypted channels [BETA]
+### Private encrypted channels
 
 Similar to Private channels, you can also subscribe to a
 [private encrypted channel](https://pusher.com/docs/channels/using_channels/encrypted-channels).

--- a/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
@@ -10,7 +10,7 @@ import com.pusher.client.connection.ConnectionStateChange;
 import com.pusher.client.util.HttpAuthorizer;
 
 /*
-This app demonstrates how to use Private Encrypted Channels [BETA].
+This app demonstrates how to use Private Encrypted Channels.
 
 Please ensure you update this relevant parts below with your Pusher credentials before running.
 and ensure you have set up an authorization endpoint with end to end encryption. Your Pusher credentials


### PR DESCRIPTION
Removing the beta label over the private encrypted channels docs.

Do not merge this PR until private encrypted channels is actually released 🎉 