### PR TITLE
2.2.0 Pusher Options encrypted to forceTLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pusher-websocket-java changelog
 
+## Version 2.2.0 - 22nd April 2020
+
+* Changed PusherOptions `setEncrypted` and `isEncrypted` to `setForceTLS` and `isForceTLS` to reduce confusion between this option and private encrypted channels.
+
 ## Version 2.1.1 - 15th April 2020
 
 * Fix a case where multiple websocket connections could be opened at once

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The pusher-java-client is available in Maven Central.
     <dependency>
       <groupId>com.pusher</groupId>
       <artifactId>pusher-java-client</artifactId>
-      <version>2.1.1</version>
+      <version>2.2.0</version>
     </dependency>
 </dependencies>
 ```
@@ -70,7 +70,7 @@ The pusher-java-client is available in Maven Central.
 
 ```groovy
 dependencies {
-  compile 'com.pusher:pusher-java-client:2.1.1'
+  compile 'com.pusher:pusher-java-client:2.2.0'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'signing'
 apply plugin: 'jacoco'
 
 group = "com.pusher"
-version = "2.1.1"
+version = "2.2.0"
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 

--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -74,7 +74,7 @@ public class PusherOptions {
      * @param forceTLS whether the connection should use TLS, by default this is true
      * @return this, for chaining
      */
-    public PusherOptions setForceTLS(boolean forceTLS) {
+    public PusherOptions setForceTLS(final boolean forceTLS) {
         this.forceTLS = forceTLS;
         return this;
     }

--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -34,7 +34,7 @@ public class PusherOptions {
     private String host = "ws.pusherapp.com";
     private int wsPort = WS_PORT;
     private int wssPort = WSS_PORT;
-    private boolean encrypted = true;
+    private boolean forceTLS = true;
     private long activityTimeout = DEFAULT_ACTIVITY_TIMEOUT;
     private long pongTimeout = DEFAULT_PONG_TIMEOUT;
     private Authorizer authorizer;
@@ -43,24 +43,39 @@ public class PusherOptions {
     private int maxReconnectGapInSeconds = MAX_RECONNECT_GAP_IN_SECONDS;
 
     /**
-     * Gets whether an encrypted (SSL) connection should be used when connecting
-     * to Pusher.
-     *
-     * @return true if an encrypted connection should be used; otherwise false.
+     * @deprecated
+     * Please use isForceTLS
      */
+    @Deprecated
     public boolean isEncrypted() {
-        return encrypted;
+        return forceTLS;
     }
 
     /**
-     * Sets whether an encrypted (SSL) connection should be used when connecting to
-     * Pusher.
+     * @deprecated
+     * Please use setForceTLS
+     */
+    @Deprecated
+    public PusherOptions setEncrypted(final boolean encrypted) {
+        this.forceTLS = encrypted;
+        return this;
+    }
+
+    /**
      *
-     * @param encrypted Whether to use an SSL connection
+     * @return whether the connection to Pusher should use TLS
+     */
+    public boolean isForceTLS() {
+        return forceTLS;
+    }
+
+    /**
+     * Sets whether the connection to Pusher should be use TLS.
+     * @param forceTLS whether the connection should use TLS, by default this is true
      * @return this, for chaining
      */
-    public PusherOptions setEncrypted(final boolean encrypted) {
-        this.encrypted = encrypted;
+    public PusherOptions setForceTLS(boolean forceTLS) {
+        this.forceTLS = forceTLS;
         return this;
     }
 
@@ -103,7 +118,7 @@ public class PusherOptions {
     }
 
     /**
-     * The port to which unencrypted connections will be made.
+     * The port to which non TLS connections will be made.
      *
      * Note that if you wish to connect to a standard Pusher cluster, the
      * convenience method setCluster will set the host and ports correctly from
@@ -222,7 +237,7 @@ public class PusherOptions {
      * @return the WebSocket URL
      */
     public String buildUrl(final String apiKey) {
-        return String.format("%s://%s:%s/app/%s%s", encrypted ? WSS_SCHEME : WS_SCHEME, host, encrypted ? wssPort
+        return String.format("%s://%s:%s/app/%s%s", forceTLS ? WSS_SCHEME : WS_SCHEME, host, forceTLS ? wssPort
                 : wsPort, apiKey, URI_SUFFIX);
     }
 

--- a/src/main/java/com/pusher/client/example/ExampleApp.java
+++ b/src/main/java/com/pusher/client/example/ExampleApp.java
@@ -47,7 +47,7 @@ public class ExampleApp {
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
-                .setEncrypted(true)
+                .setForceTLS(true)
                 .setCluster(cluster);
         Pusher pusher = new Pusher(channelsKey, options);
 

--- a/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
@@ -56,7 +56,7 @@ public class PresenceChannelExampleApp {
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
-                .setEncrypted(true)
+                .setForceTLS(true)
                 .setCluster(cluster)
                 .setAuthorizer(authorizer);
         Pusher pusher = new Pusher(channelsKey, options);

--- a/src/main/java/com/pusher/client/example/PrivateChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateChannelExampleApp.java
@@ -54,7 +54,7 @@ public class PrivateChannelExampleApp {
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
-                .setEncrypted(true)
+                .setForceTLS(true)
                 .setCluster(cluster)
                 .setAuthorizer(authorizer);
         Pusher pusher = new Pusher(channelsKey, options);

--- a/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
@@ -60,7 +60,7 @@ public class PrivateEncryptedChannelExampleApp {
         final PusherOptions options = new PusherOptions()
                 .setCluster(cluster)
                 .setAuthorizer(authorizer)
-                .setEncrypted(true);
+                .setForceTLS(true);
         Pusher pusher = new Pusher(channelsKey, options);
 
         // set up a ConnectionEventListener to listen for connection changes to Pusher

--- a/src/test/java/com/pusher/client/PusherOptionsTest.java
+++ b/src/test/java/com/pusher/client/PusherOptionsTest.java
@@ -1,16 +1,17 @@
 package com.pusher.client;
 
-import static org.junit.Assert.*;
-
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PusherOptionsTest {
@@ -31,6 +32,11 @@ public class PusherOptionsTest {
     }
 
     @Test
+    public void testForceTLSInitializedAsTrue() {
+        assert pusherOptions.isForceTLS();
+    }
+
+    @Test
     public void testAuthorizerIsInitiallyNull() {
         assertNull(pusherOptions.getAuthorizer());
     }
@@ -48,6 +54,12 @@ public class PusherOptionsTest {
     }
 
     @Test
+    public void testForceTLSCanBeSetToTrue() {
+        pusherOptions.setForceTLS(true);
+        assertSame(true, pusherOptions.isForceTLS());
+    }
+
+    @Test
     public void testSetAuthorizerReturnsSelf() {
         assertSame(pusherOptions, pusherOptions.setAuthorizer(mockAuthorizer));
     }
@@ -58,6 +70,11 @@ public class PusherOptionsTest {
     }
 
     @Test
+    public void testSetForceTLSReturnsSelf() {
+        assertSame(pusherOptions, pusherOptions.setForceTLS(true));
+    }
+
+    @Test
     public void testDefaultURL() {
         assertEquals(pusherOptions.buildUrl(API_KEY), "wss://ws.pusherapp.com:443/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
@@ -65,7 +82,7 @@ public class PusherOptionsTest {
 
     @Test
     public void testNonSSLURLIsCorrect() {
-        pusherOptions.setEncrypted(false);
+        pusherOptions.setForceTLS(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://ws.pusherapp.com:80/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }
@@ -79,7 +96,7 @@ public class PusherOptionsTest {
 
     @Test
     public void testClusterSetNonSSLURLIsCorrect() {
-        pusherOptions.setCluster("eu").setEncrypted(false);
+        pusherOptions.setCluster("eu").setForceTLS(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://ws-eu.pusher.com:80/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }
@@ -93,7 +110,7 @@ public class PusherOptionsTest {
 
     @Test
     public void testCustomHostAndPortNonSSLURLIsCorrect() {
-        pusherOptions.setHost("subdomain.example.com").setWsPort(8080).setWssPort(8181).setEncrypted(false);
+        pusherOptions.setHost("subdomain.example.com").setWsPort(8080).setWssPort(8181).setForceTLS(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://subdomain.example.com:8080/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }


### PR DESCRIPTION
### Description of the pull request
Refactored the PusherOption `encrypted` to `forceTLS`. Have annotated with `@deprecated` the previous methods to let existing people know.
...

#### Why is the change necessary?
The other libraries updated to `forceTLS` to reduce confusion between private encrypted channels.
...

----

CC @pusher/mobile 
