### PR TITLE
PusherOptions useTLS instead of forceTLS

### DIFF
--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -34,7 +34,7 @@ public class PusherOptions {
     private String host = "ws.pusherapp.com";
     private int wsPort = WS_PORT;
     private int wssPort = WSS_PORT;
-    private boolean forceTLS = true;
+    private boolean useTLS = true;
     private long activityTimeout = DEFAULT_ACTIVITY_TIMEOUT;
     private long pongTimeout = DEFAULT_PONG_TIMEOUT;
     private Authorizer authorizer;
@@ -43,21 +43,38 @@ public class PusherOptions {
     private int maxReconnectGapInSeconds = MAX_RECONNECT_GAP_IN_SECONDS;
 
     /**
-     * @deprecated
-     * Please use isForceTLS
+     * @deprecated 2.2.0
+     * Please use isUseTLS
      */
     @Deprecated
     public boolean isEncrypted() {
-        return forceTLS;
+        return useTLS;
     }
 
     /**
-     * @deprecated
-     * Please use setForceTLS
+     * @deprecated 2.2.0
+     * Please use setUseTLS
      */
     @Deprecated
     public PusherOptions setEncrypted(final boolean encrypted) {
-        this.forceTLS = encrypted;
+        this.useTLS = encrypted;
+        return this;
+    }
+
+    /**
+     * @deprecated 2.3.0
+     * Please use isUseTLS
+     */
+    public boolean isForceTLS() {
+        return useTLS;
+    }
+
+    /**
+     * @deprecated 2.3.0
+     * Please use setUseTLS
+     */
+    public PusherOptions setForceTLS(final boolean forceTLS) {
+        this.useTLS = forceTLS;
         return this;
     }
 
@@ -65,8 +82,8 @@ public class PusherOptions {
      *
      * @return whether the connection to Pusher should use TLS
      */
-    public boolean isForceTLS() {
-        return forceTLS;
+    public boolean isUseTLS() {
+        return useTLS;
     }
 
     /**
@@ -74,8 +91,8 @@ public class PusherOptions {
      * @param forceTLS whether the connection should use TLS, by default this is true
      * @return this, for chaining
      */
-    public PusherOptions setForceTLS(final boolean forceTLS) {
-        this.forceTLS = forceTLS;
+    public PusherOptions setUseTLS(final boolean forceTLS) {
+        this.useTLS = forceTLS;
         return this;
     }
 
@@ -237,7 +254,7 @@ public class PusherOptions {
      * @return the WebSocket URL
      */
     public String buildUrl(final String apiKey) {
-        return String.format("%s://%s:%s/app/%s%s", forceTLS ? WSS_SCHEME : WS_SCHEME, host, forceTLS ? wssPort
+        return String.format("%s://%s:%s/app/%s%s", useTLS ? WSS_SCHEME : WS_SCHEME, host, useTLS ? wssPort
                 : wsPort, apiKey, URI_SUFFIX);
     }
 

--- a/src/main/java/com/pusher/client/example/ExampleApp.java
+++ b/src/main/java/com/pusher/client/example/ExampleApp.java
@@ -47,7 +47,7 @@ public class ExampleApp {
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
-                .setForceTLS(true)
+                .setUseTLS(true)
                 .setCluster(cluster);
         Pusher pusher = new Pusher(channelsKey, options);
 

--- a/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
@@ -56,7 +56,7 @@ public class PresenceChannelExampleApp {
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
-                .setForceTLS(true)
+                .setUseTLS(true)
                 .setCluster(cluster)
                 .setAuthorizer(authorizer);
         Pusher pusher = new Pusher(channelsKey, options);

--- a/src/main/java/com/pusher/client/example/PrivateChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateChannelExampleApp.java
@@ -54,7 +54,7 @@ public class PrivateChannelExampleApp {
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
-                .setForceTLS(true)
+                .setUseTLS(true)
                 .setCluster(cluster)
                 .setAuthorizer(authorizer);
         Pusher pusher = new Pusher(channelsKey, options);

--- a/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
@@ -60,7 +60,7 @@ public class PrivateEncryptedChannelExampleApp {
         final PusherOptions options = new PusherOptions()
                 .setCluster(cluster)
                 .setAuthorizer(authorizer)
-                .setForceTLS(true);
+                .setUseTLS(true);
         Pusher pusher = new Pusher(channelsKey, options);
 
         // set up a ConnectionEventListener to listen for connection changes to Pusher

--- a/src/test/java/com/pusher/client/PusherOptionsTest.java
+++ b/src/test/java/com/pusher/client/PusherOptionsTest.java
@@ -37,6 +37,11 @@ public class PusherOptionsTest {
     }
 
     @Test
+    public void testUseTLSInitializedAsTrue() {
+        assert pusherOptions.isUseTLS();
+    }
+
+    @Test
     public void testAuthorizerIsInitiallyNull() {
         assertNull(pusherOptions.getAuthorizer());
     }
@@ -60,6 +65,12 @@ public class PusherOptionsTest {
     }
 
     @Test
+    public void testUseTLSCanBeSetToTrue() {
+        pusherOptions.setUseTLS(true);
+        assertSame(true, pusherOptions.isUseTLS());
+    }
+
+    @Test
     public void testSetAuthorizerReturnsSelf() {
         assertSame(pusherOptions, pusherOptions.setAuthorizer(mockAuthorizer));
     }
@@ -75,6 +86,11 @@ public class PusherOptionsTest {
     }
 
     @Test
+    public void testSetUseTLSReturnsSelf() {
+        assertSame(pusherOptions, pusherOptions.setUseTLS(true));
+    }
+
+    @Test
     public void testDefaultURL() {
         assertEquals(pusherOptions.buildUrl(API_KEY), "wss://ws.pusherapp.com:443/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
@@ -82,7 +98,7 @@ public class PusherOptionsTest {
 
     @Test
     public void testNonSSLURLIsCorrect() {
-        pusherOptions.setForceTLS(false);
+        pusherOptions.setUseTLS(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://ws.pusherapp.com:80/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }
@@ -96,7 +112,7 @@ public class PusherOptionsTest {
 
     @Test
     public void testClusterSetNonSSLURLIsCorrect() {
-        pusherOptions.setCluster("eu").setForceTLS(false);
+        pusherOptions.setCluster("eu").setUseTLS(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://ws-eu.pusher.com:80/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }
@@ -110,7 +126,7 @@ public class PusherOptionsTest {
 
     @Test
     public void testCustomHostAndPortNonSSLURLIsCorrect() {
-        pusherOptions.setHost("subdomain.example.com").setWsPort(8080).setWssPort(8181).setForceTLS(false);
+        pusherOptions.setHost("subdomain.example.com").setWsPort(8080).setWssPort(8181).setUseTLS(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://subdomain.example.com:8080/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }


### PR DESCRIPTION
### Description of the pull request
Refactored interface to `useTLS` instead of `forceTLS`.
...

#### Why is the change necessary?
We want to be consistent with the other client frameworks
...

----

CC @pusher/mobile 
