### PR TITLE
Refactor PusherOptions forceTLS to useTLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pusher-websocket-java changelog
 
+### Version 2.2.1 - 22nd April 2020
+
+* Changed PusherOptions `setForceTLS` and `isForceTLS` to `setUseTLS` and `isUseTLS` to align with the other client SDKs.
+
 ## Version 2.2.0 - 22nd April 2020
 
 * Changed PusherOptions `setEncrypted` and `isEncrypted` to `setForceTLS` and `isForceTLS` to reduce confusion between this option and private encrypted channels.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The pusher-java-client is available in Maven Central.
     <dependency>
       <groupId>com.pusher</groupId>
       <artifactId>pusher-java-client</artifactId>
-      <version>2.2.0</version>
+      <version>2.2.1</version>
     </dependency>
 </dependencies>
 ```
@@ -70,7 +70,7 @@ The pusher-java-client is available in Maven Central.
 
 ```groovy
 dependencies {
-  compile 'com.pusher:pusher-java-client:2.2.0'
+  compile 'com.pusher:pusher-java-client:2.2.1'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ apply plugin: 'signing'
 apply plugin: 'jacoco'
 
 group = "com.pusher"
-version = "2.2.0"
+version = "2.2.1"
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 

--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -34,7 +34,7 @@ public class PusherOptions {
     private String host = "ws.pusherapp.com";
     private int wsPort = WS_PORT;
     private int wssPort = WSS_PORT;
-    private boolean forceTLS = true;
+    private boolean useTLS = true;
     private long activityTimeout = DEFAULT_ACTIVITY_TIMEOUT;
     private long pongTimeout = DEFAULT_PONG_TIMEOUT;
     private Authorizer authorizer;
@@ -44,20 +44,20 @@ public class PusherOptions {
 
     /**
      * @deprecated
-     * Please use isForceTLS
+     * Please use isUseTLS
      */
     @Deprecated
     public boolean isEncrypted() {
-        return forceTLS;
+        return useTLS;
     }
 
     /**
      * @deprecated
-     * Please use setForceTLS
+     * Please use setUseTLS
      */
     @Deprecated
     public PusherOptions setEncrypted(final boolean encrypted) {
-        this.forceTLS = encrypted;
+        this.useTLS = encrypted;
         return this;
     }
 
@@ -65,17 +65,17 @@ public class PusherOptions {
      *
      * @return whether the connection to Pusher should use TLS
      */
-    public boolean isForceTLS() {
-        return forceTLS;
+    public boolean isUseTLS() {
+        return useTLS;
     }
 
     /**
      * Sets whether the connection to Pusher should be use TLS.
-     * @param forceTLS whether the connection should use TLS, by default this is true
+     * @param useTLS whether the connection should use TLS, by default this is true
      * @return this, for chaining
      */
-    public PusherOptions setForceTLS(final boolean forceTLS) {
-        this.forceTLS = forceTLS;
+    public PusherOptions setUseTLS(final boolean useTLS) {
+        this.useTLS = useTLS;
         return this;
     }
 
@@ -237,7 +237,7 @@ public class PusherOptions {
      * @return the WebSocket URL
      */
     public String buildUrl(final String apiKey) {
-        return String.format("%s://%s:%s/app/%s%s", forceTLS ? WSS_SCHEME : WS_SCHEME, host, forceTLS ? wssPort
+        return String.format("%s://%s:%s/app/%s%s", useTLS ? WSS_SCHEME : WS_SCHEME, host, useTLS ? wssPort
                 : wsPort, apiKey, URI_SUFFIX);
     }
 

--- a/src/main/java/com/pusher/client/example/ExampleApp.java
+++ b/src/main/java/com/pusher/client/example/ExampleApp.java
@@ -1,9 +1,5 @@
 package com.pusher.client.example;
 
-import java.util.Map;
-
-import com.google.gson.Gson;
-
 import com.pusher.client.Pusher;
 import com.pusher.client.PusherOptions;
 import com.pusher.client.channel.Channel;
@@ -47,7 +43,7 @@ public class ExampleApp {
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
-                .setForceTLS(true)
+                .setUseTLS(true)
                 .setCluster(cluster);
         Pusher pusher = new Pusher(channelsKey, options);
 

--- a/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
@@ -4,7 +4,6 @@ import java.util.Set;
 
 import com.pusher.client.Pusher;
 import com.pusher.client.PusherOptions;
-import com.pusher.client.channel.PrivateChannelEventListener;
 import com.pusher.client.channel.PusherEvent;
 import com.pusher.client.channel.PresenceChannel;
 import com.pusher.client.channel.PresenceChannelEventListener;
@@ -56,7 +55,7 @@ public class PresenceChannelExampleApp {
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
-                .setForceTLS(true)
+                .setUseTLS(true)
                 .setCluster(cluster)
                 .setAuthorizer(authorizer);
         Pusher pusher = new Pusher(channelsKey, options);

--- a/src/main/java/com/pusher/client/example/PrivateChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateChannelExampleApp.java
@@ -2,8 +2,6 @@ package com.pusher.client.example;
 
 import com.pusher.client.Pusher;
 import com.pusher.client.PusherOptions;
-import com.pusher.client.channel.Channel;
-import com.pusher.client.channel.ChannelEventListener;
 import com.pusher.client.channel.PusherEvent;
 import com.pusher.client.channel.PrivateChannel;
 import com.pusher.client.channel.PrivateChannelEventListener;
@@ -54,7 +52,7 @@ public class PrivateChannelExampleApp {
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
-                .setForceTLS(true)
+                .setUseTLS(true)
                 .setCluster(cluster)
                 .setAuthorizer(authorizer);
         Pusher pusher = new Pusher(channelsKey, options);

--- a/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
@@ -2,7 +2,6 @@ package com.pusher.client.example;
 
 import com.pusher.client.Pusher;
 import com.pusher.client.PusherOptions;
-import com.pusher.client.channel.PrivateChannelEventListener;
 import com.pusher.client.channel.PrivateEncryptedChannel;
 import com.pusher.client.channel.PrivateEncryptedChannelEventListener;
 import com.pusher.client.channel.PusherEvent;
@@ -60,7 +59,7 @@ public class PrivateEncryptedChannelExampleApp {
         final PusherOptions options = new PusherOptions()
                 .setCluster(cluster)
                 .setAuthorizer(authorizer)
-                .setForceTLS(true);
+                .setUseTLS(true);
         Pusher pusher = new Pusher(channelsKey, options);
 
         // set up a ConnectionEventListener to listen for connection changes to Pusher

--- a/src/test/java/com/pusher/client/PusherOptionsTest.java
+++ b/src/test/java/com/pusher/client/PusherOptionsTest.java
@@ -32,8 +32,8 @@ public class PusherOptionsTest {
     }
 
     @Test
-    public void testForceTLSInitializedAsTrue() {
-        assert pusherOptions.isForceTLS();
+    public void testUseTLSInitializedAsTrue() {
+        assert pusherOptions.isUseTLS();
     }
 
     @Test
@@ -54,9 +54,9 @@ public class PusherOptionsTest {
     }
 
     @Test
-    public void testForceTLSCanBeSetToTrue() {
-        pusherOptions.setForceTLS(true);
-        assertSame(true, pusherOptions.isForceTLS());
+    public void testUseTLSCanBeSetToTrue() {
+        pusherOptions.setUseTLS(true);
+        assertSame(true, pusherOptions.isUseTLS());
     }
 
     @Test
@@ -70,8 +70,8 @@ public class PusherOptionsTest {
     }
 
     @Test
-    public void testSetForceTLSReturnsSelf() {
-        assertSame(pusherOptions, pusherOptions.setForceTLS(true));
+    public void testSetUseTLSReturnsSelf() {
+        assertSame(pusherOptions, pusherOptions.setUseTLS(true));
     }
 
     @Test
@@ -82,7 +82,7 @@ public class PusherOptionsTest {
 
     @Test
     public void testNonSSLURLIsCorrect() {
-        pusherOptions.setForceTLS(false);
+        pusherOptions.setUseTLS(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://ws.pusherapp.com:80/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }
@@ -96,7 +96,7 @@ public class PusherOptionsTest {
 
     @Test
     public void testClusterSetNonSSLURLIsCorrect() {
-        pusherOptions.setCluster("eu").setForceTLS(false);
+        pusherOptions.setCluster("eu").setUseTLS(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://ws-eu.pusher.com:80/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }
@@ -110,7 +110,7 @@ public class PusherOptionsTest {
 
     @Test
     public void testCustomHostAndPortNonSSLURLIsCorrect() {
-        pusherOptions.setHost("subdomain.example.com").setWsPort(8080).setWssPort(8181).setForceTLS(false);
+        pusherOptions.setHost("subdomain.example.com").setWsPort(8080).setWssPort(8181).setUseTLS(false);
         assertEquals(pusherOptions.buildUrl(API_KEY), "ws://subdomain.example.com:8080/app/" + API_KEY
                 + "?client=java-client&protocol=5&version=" + PusherOptions.LIB_VERSION);
     }


### PR DESCRIPTION
### Description of the pull request
Refactor PusherOptions `forceTLS` to `useTLS`
...

#### Why is the change necessary?
We want to be consistent with our public interface between client sdks
...

----

CC @pusher/mobile 
