### PR TITLE
Read the error stream when server response is 400 or above

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,7 @@ dependencies {
 	testCompile "org.mockito:mockito-all:1.8.5"
 	testCompile "org.powermock:powermock-module-junit4:1.4.11"
 	testCompile "org.powermock:powermock-api-mockito:1.4.11"
+	testImplementation "org.mock-server:mockserver-netty:5.10.0"
 
 	testImplementation "com.google.truth:truth:1.0.1"
 }

--- a/src/main/java/com/pusher/client/util/HttpAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpAuthorizer.java
@@ -14,6 +14,8 @@ import java.util.HashMap;
 import java.util.Map;
 import javax.net.ssl.HttpsURLConnection;
 
+import static java.net.HttpURLConnection.HTTP_BAD_REQUEST;
+
 /**
  * Used to authenticate a {@link com.pusher.client.channel.PrivateChannel
  * private} or {@link com.pusher.client.channel.PresenceChannel presence}
@@ -110,7 +112,7 @@ public class HttpAuthorizer implements Authorizer {
             defaultHeaders.putAll(mHeaders);
             // Add in the Content-Length, so it can't be overwritten by mHeaders
             defaultHeaders.put("Content-Length","" + Integer.toString(body.getBytes().length));
-            
+
             for (final String headerName : defaultHeaders.keySet()) {
                 final String headerValue = defaultHeaders.get(headerName);
                 connection.setRequestProperty(headerName, headerValue);
@@ -125,7 +127,7 @@ public class HttpAuthorizer implements Authorizer {
             wr.close();
 
             // Read response
-            final InputStream is = connection.getInputStream();
+            final InputStream is = getResponseInputStream(connection);
             final BufferedReader rd = new BufferedReader(new InputStreamReader(is));
             String line;
             final StringBuffer response = new StringBuffer();
@@ -145,5 +147,12 @@ public class HttpAuthorizer implements Authorizer {
         catch (final IOException e) {
             throw new AuthorizationFailureException(e);
         }
+    }
+
+    private InputStream getResponseInputStream(HttpURLConnection connection) throws IOException {
+        if (connection.getResponseCode() >= HTTP_BAD_REQUEST) {
+            return connection.getErrorStream();
+        }
+        return connection.getInputStream();
     }
 }

--- a/src/test/java/com/pusher/client/util/HttpAuthorizerTest.java
+++ b/src/test/java/com/pusher/client/util/HttpAuthorizerTest.java
@@ -1,12 +1,27 @@
 package com.pusher.client.util;
 
-import junit.framework.Assert;
-
-import org.junit.Test;
-
 import com.pusher.client.AuthorizationFailureException;
+import junit.framework.Assert;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.mockserver.integration.ClientAndServer;
+
+import static com.google.common.truth.Truth.assertThat;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static org.mockserver.integration.ClientAndServer.startClientAndServer;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
 
 public class HttpAuthorizerTest {
+
+    private static ClientAndServer mockServer;
+
+    @BeforeClass
+    public static void startMockServer() {
+        mockServer = startClientAndServer(1080);
+    }
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructWithMalformedURLThrowsRuntimeException() {
@@ -29,5 +44,41 @@ public class HttpAuthorizerTest {
     public void testNon200ResponseThrowsAuthorizationFailureException() {
         final HttpAuthorizer auth = new HttpAuthorizer("https://127.0.0.1/no-way-this-is-a-valid-url");
         auth.authorize("private-fish", "some socket id");
+    }
+
+    @Test
+    public void testResponseStatusHttpBadRequestOrAboveThrowsAuthorizationExceptionWithDetailedErrorMessage() {
+        String errorResponseMessage = "No cats allowed";
+        mockServer.when(request().withPath("/no-way-this-is-a-valid-url/wanna-bet"))
+                .respond(response()
+                        .withStatusCode(HTTP_FORBIDDEN)
+                        .withBody(errorResponseMessage)
+                );
+        final HttpAuthorizer auth = new HttpAuthorizer("http://127.0.0.1:1080/no-way-this-is-a-valid-url/wanna-bet");
+
+        try {
+            auth.authorize("private-dog", "barking");
+        } catch (AuthorizationFailureException e) {
+                assertThat(e).hasMessageThat().isEqualTo(errorResponseMessage);
+        }
+    }
+
+    @Test
+    public void testResponseStatusLowerThanHttpBadRequestReturnsSuccessResponse() {
+        String expectedResponseMessage = "Keep on purring";
+        mockServer.when(request().withPath("/no-way-this-is-a-valid-url/wanna-bet"))
+                .respond(response()
+                        .withStatusCode(HTTP_OK)
+                        .withBody(expectedResponseMessage)
+                );
+        final HttpAuthorizer auth = new HttpAuthorizer("http://127.0.0.1:1080/no-way-this-is-a-valid-url/wanna-bet");
+
+        String responseMessage = auth.authorize("private-cat", "purring");
+        assertThat(responseMessage).isEqualTo(expectedResponseMessage);
+    }
+
+    @AfterClass
+    public static void stopMockServer() {
+        mockServer.stop();
     }
 }


### PR DESCRIPTION
### Description of the pull request

Retrieve the errorStream when the server responds with status code 400 or above.
See issue https://github.com/pusher/pusher-websocket-java/issues/261

#### Why is the change necessary?

When receiving a 400 or above from the server a FileNotFoundException is thrown when trying to retrieve the inputStream from the connection. As per HttpURLConnection's implementation the errorStream should be retrieved in order to read the error response and act appropriate on it. 

E.g. when receiving a 403 from the server while trying to subscribe to a private channel. In some cases the client needs to know what the server responded to perform some cleanup or give an appropriate error message to the end user of the client.

----

CC @pusher/mobile 
