### PR TITLE
Update Java-WebSocket dependency to 1.5.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ repositories {
 
 dependencies {
 	compile "com.google.code.gson:gson:2.2.2"
-	compile "org.java-websocket:Java-WebSocket:1.4.0"
+	compile "org.java-websocket:Java-WebSocket:1.5.1"
 
 	testCompile "org.mockito:mockito-all:1.8.5"
 	testCompile "org.powermock:powermock-module-junit4:1.4.11"


### PR DESCRIPTION
### Description of the pull request
Updated the Java-WebSocket dependency to 1.5.1.
...

#### Why is the change necessary?
It was reported to us that in #279 that there is a vulnerability in the current version of the dependency and we should update asap
...

