### PR TITLE
Fix websocket issue with pre android sdk 24 devices

### DIFF
--- a/src/main/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImpl.java
@@ -185,7 +185,7 @@ public class PrivateEncryptedChannelImpl extends ChannelImpl implements PrivateE
                 encryptedReceivedData.getCiphertext(),
                 encryptedReceivedData.getNonce());
 
-        receivedMessage.replace("data", decryptedData);
+        receivedMessage.put("data", decryptedData);
 
         return new PusherEvent(receivedMessage);
     }

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketClientWrapper.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketClientWrapper.java
@@ -8,6 +8,7 @@ import java.security.NoSuchAlgorithmException;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLException;
+import javax.net.ssl.SSLParameters;
 import javax.net.ssl.SSLSocketFactory;
 
 import org.java_websocket.client.WebSocketClient;
@@ -88,5 +89,10 @@ public class WebSocketClientWrapper extends WebSocketClient {
      */
     public void removeWebSocketListener() {
         webSocketListener = null;
+    }
+
+    @Override
+    protected void onSetSSLParameters(SSLParameters sslParameters) {
+        // https://github.com/TooTallNate/Java-WebSocket/wiki/No-such-method-error-setEndpointIdentificationAlgorithm
     }
 }

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketClientWrapper.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketClientWrapper.java
@@ -94,5 +94,10 @@ public class WebSocketClientWrapper extends WebSocketClient {
     @Override
     protected void onSetSSLParameters(SSLParameters sslParameters) {
         // https://github.com/TooTallNate/Java-WebSocket/wiki/No-such-method-error-setEndpointIdentificationAlgorithm
+        try {
+            super.onSetSSLParameters(sslParameters);
+        } catch (NoSuchMethodError error) {
+            // if this is being called on an android device pre-24 this api isn't available
+        }
     }
 }


### PR DESCRIPTION
### Description of the pull request
Issue #283 when we updated the websocket library.

I could reproduce this crash myself with an emulator running 5.1 and the current version of the library.

I followed the [instructions on the websocket library](https://github.com/TooTallNate/Java-WebSocket/wiki/No-such-method-error-setEndpointIdentificationAlgorithm) to fix this issue. There was a discussion around the issue for those interested [here](https://github.com/TooTallNate/Java-WebSocket/issues/1011). And the [public interface](https://github.com/TooTallNate/Java-WebSocket/blob/1.5.1/src/main/java/org/java_websocket/client/WebSocketClient.java#L526) has been documented.

I have also surrounded the call super method with a try so android 24+ devices can get the benefit.

I have tested on my emulator that this version does not crash and connects as expected.

### Additional
Turned out there was an issue with using `map.replace` for the encrypted channels on old versions of android - I fixed this too by using `map.put` instead.