### PR TITLE
Change log level of updateState from fine to info

### DIFF
--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -150,7 +150,7 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
     /* implementation detail */
 
     private void updateState(final ConnectionState newState) {
-        log.fine("State transition requested, current [" + state + "], new [" + newState + "]");
+        log.info("State transition requested, current [" + state + "], new [" + newState + "]");
 
         final ConnectionStateChange change = new ConnectionStateChange(state, newState);
         state = newState;


### PR DESCRIPTION
### Description of the pull request

Change a logging call from `fine` to `info` in order to fix the logging present in WebSocketConnection

#### Why is the change necessary?

The WebSocketConnection class configures a logger:
https://github.com/pusher/pusher-websocket-java/blob/93c25bcd440b837c7214375f0bdbf1ba99b3e2a9/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java#L28

And then sends out a message with level 'fine':

https://github.com/pusher/pusher-websocket-java/blob/93c25bcd440b837c7214375f0bdbf1ba99b3e2a9/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java#L153

This message will never be shown because the default minimum log level is `Level.Info`, and `Level.Fine` is below that.

Alternatively, the logger's Level could be set to `Level.Fine`, however reading through the underlying code this could cause unintended side effects since it eventually modifies properties in a static class.

----

CC @pusher/mobile 
