### PR TITLE
Should use https

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ dependencies {
 
 ### Download
 
-You can download a version of the `.jar` directly from <http://repo1.maven.org/maven2/com/pusher/pusher-java-client/>
+You can download a version of the `.jar` directly from <https://repo1.maven.org/maven2/com/pusher/pusher-java-client/>
 
 ### Source
 


### PR DESCRIPTION
### Description of the pull request

Clicking on the link produce an error:

501 HTTPS Required. 
Use https://repo1.maven.org/maven2/
More information at https://links.sonatype.com/central/501-https-required
  
...

#### Why is the change necessary?

...

----

CC @pusher/mobile 
