### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,7 +551,7 @@ For more information on how and why there is a `socket_id` see the documentation
 Channel channel = pusher.getChannel("my-channel");
 ```
 
-The library will raise an exception if the parameter to `Pusher#getPrivateChannel` is prefixed with `"private-"` or `"presence-"`.
+The library will raise an exception if the parameter to `Pusher#getChannel` is prefixed with `"private-"` or `"presence-"`.
 
 #### Private channels
 


### PR DESCRIPTION
### Description of the pull request

Fixing a typo in the README.md that was likely a copy paste error. The text refers to the wrong function.

#### Why is the change necessary?

As it is, the text is incorrect.

----

CC @pusher/mobile 
