### PR TITLE
Use correct jar file name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -627,8 +627,8 @@ From the top level directory execute:
 
 ### Run the Example Application
 
-After running `gradlew clean assemble` change to the `build/libs` directory and run `java -jar pusher-java-client-<version>-jar-with-dependencies.jar`. This will run the example application.
+After running `gradlew clean assemble` change to the `build/libs` directory and run `java -jar pusher-websocket-java-with-dependencies-<version>-jar-with-dependencies.jar`. This will run the example application.
 
 By default the example will connect to a sample application and subscribe to the channel `my-channel`, listening to events on `my-event`. If you want to change these defaults, they can be specified on the command line:
 
-`java -jar pusher-java-client-<version>-jar-with-dependencies.jar [appKey] [channelName] [eventName]`
+`java -jar pusher-websocket-java-with-dependencies-<version>-jar-with-dependencies.jar [appKey] [channelName] [eventName]`


### PR DESCRIPTION
### Description of the pull request

In the README section about running the example application, the jar file name is incorrect. This updates the README to the correct jar file.

#### Why is the change necessary?

The current file name doesn't exist after a build.

----

CC @pusher/mobile 
