### PR TITLE
Update gradle wrapper from 5.0 to 7.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import org.apache.tools.ant.filters.ReplaceTokens
+
 buildscript {
     repositories {
         mavenCentral()
@@ -7,19 +9,21 @@ buildscript {
     }
 }
 
+plugins {
+    id "eclipse"
+    id "jacoco"
+    id "java-library"
+    id "maven-publish"
+    id "org.ajoberstar.github-pages" version "1.7.2"
+    id "signing"
+}
+
 def getProperty = { property ->
     if (!project.hasProperty(property)) {
         throw new GradleException("${property} property must be set")
     }
     return project.property(property)
 }
-
-apply plugin: 'java'
-apply plugin: 'maven'
-apply plugin: 'eclipse'
-apply plugin: 'org.ajoberstar.github-pages'
-apply plugin: 'signing'
-apply plugin: 'jacoco'
 
 group = "com.pusher"
 version = "2.2.8"
@@ -40,23 +44,21 @@ ext.sharedManifest = manifest {
 
 repositories {
     mavenCentral()
-    jcenter()
 }
 
 dependencies {
-    compile "com.google.code.gson:gson:2.8.9"
-    compile "org.java-websocket:Java-WebSocket:1.5.1"
+    implementation "com.google.code.gson:gson:2.8.9"
+    implementation "org.java-websocket:Java-WebSocket:1.5.1"
 
-    testCompile "org.mockito:mockito-all:1.8.5"
-    testCompile "org.powermock:powermock-module-junit4:1.4.11"
-    testCompile "org.powermock:powermock-api-mockito:1.4.11"
-
+    testImplementation "org.mockito:mockito-all:1.8.5"
+    testImplementation "org.powermock:powermock-module-junit4:1.4.11"
+    testImplementation "org.powermock:powermock-api-mockito:1.4.11"
     testImplementation "com.google.truth:truth:1.0.1"
 }
 
 
 processResources {
-    filter(org.apache.tools.ant.filters.ReplaceTokens, tokens: [
+    filter(ReplaceTokens, tokens: [
         version: project.version
     ] )
 }
@@ -85,32 +87,30 @@ jar {
     }
 }
 
-
-task fatJar(type: Jar, dependsOn:configurations.runtime) {
+task fatJar(type: Jar, dependsOn:configurations.runtimeClasspath) {
     manifest = project.manifest {
         from sharedManifest
     }
-    baseName = project.name + '-with-dependencies'
-    from { configurations.runtime.collect { it.isDirectory() ? it : zipTree(it) } }
+    archiveBaseName.set(project.name + '-with-dependencies')
+    from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }
     with jar
-    classifier = 'jar-with-dependencies'
+    archiveClassifier.set('jar-with-dependencies')
 }
 assemble.dependsOn fatJar
 
 
 task sourcesJar(type: Jar, dependsOn: classes) {
-    classifier = 'sources'
+    archiveClassifier.set('sources')
     from sourceSets.main.allSource
 }
 assemble.dependsOn sourcesJar
 
 
 task javadocJar(type: Jar, dependsOn: javadoc) {
-    classifier = 'javadoc'
+    archiveClassifier.set('javadoc')
     from javadoc.destinationDir
 }
 assemble.dependsOn javadocJar
-
 
 githubPages {
     repoUri = 'https://github.com/pusher/pusher-websocket-java.git'
@@ -124,84 +124,77 @@ githubPages {
     }
 }
 
-
-signing {
-    required { gradle.taskGraph.hasTask("uploadArchives") }
-    sign configurations.archives
-}
-
 artifacts {
     archives jar, fatJar, sourcesJar, javadocJar
 }
 
-task createPublishTarget {
-    doLast {
-        uploadArchives { repositories { mavenDeployer {
-            beforeDeployment {
-                MavenDeployment deployment -> signing.signPom(deployment)
-            }
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
-                authentication(
-                    userName: getProperty("maven.username"),
-                    password: getProperty("maven.password")
-                )
-            }
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
-                authentication(
-                    userName: getProperty("maven.username"),
-                    password: getProperty("maven.password")
-                )
-            }
-            pom.project {
-                name 'Pusher Java Client Library'
-                packaging 'jar'
-                artifactId 'pusher-java-client'
-                description 'This is a Java client library for Pusher, targeted at core Java and Android.'
-                url 'http://github.com/pusher/pusher-websocket-java'
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            artifactId = 'pusher-java-client'
+
+            from components.java
+            pom {
+                name = 'Pusher Java Client Library'
+                packaging = 'jar'
+                artifactId = 'pusher-java-client'
+                description = 'This is a Java client library for Pusher, targeted at core Java and Android.'
+                url = 'http://github.com/pusher/pusher-websocket-java'
                 scm {
-                    connection 'scm:git:git@github.com:pusher/pusher-websocket-java'
-                    developerConnection 'scm:git:git@github.com:pusher/pusher-websocket-java'
-                    url 'http://github.com/pusher/pusher-websocket-java'
+                    connection = 'scm:git:git@github.com:pusher/pusher-websocket-java'
+                    developerConnection = 'scm:git:git@github.com:pusher/pusher-websocket-java'
+                    url = 'http://github.com/pusher/pusher-websocket-java'
                 }
                 licenses {
                     license {
-                        name 'MIT'
-                        url 'https://raw.github.com/pusher/pusher-websocket-java/master/LICENCE.txt'
-                        distribution 'https://raw.github.com/pusher/pusher-websocket-java/mvn-repo/'
+                        name = 'MIT'
+                        url = 'https://raw.github.com/pusher/pusher-websocket-java/master/LICENCE.txt'
+                        distribution = 'https://raw.github.com/pusher/pusher-websocket-java/mvn-repo/'
                     }
                 }
                 organization {
-                    name 'Pusher'
-                    url 'http://pusher.com'
+                    name = 'Pusher'
+                    url = 'http://pusher.com'
                 }
                 issueManagement {
-                    system 'GitHub'
-                    url 'https://github.com/pusher/pusher-websocket-java/issues'
+                    system = 'GitHub'
+                    url = 'https://github.com/pusher/pusher-websocket-java/issues'
                 }
                 developers {
                     developer {
-                        id 'mike'
-                        name 'Mike Pye'
-                        email 'mike@pusher.com'
+                        id = 'mike'
+                        name = 'Mike Pye'
+                        email = 'mike@pusher.com'
                     }
                 }
             }
-        }}}
+        }
+    }
+    repositories {
+        maven {
+            def releaseRepositoryUrl = "https://oss.sonatype.org/service/local/staging/deploy/maven2/"
+            def snapshotRepositoryUrl = "https://oss.sonatype.org/content/repositories/snapshots/"
+            url = version.endsWith("SNAPSHOT") ? snapshotRepositoryUrl : releaseRepositoryUrl
+            credentials {
+                username = findProperty("maven.username") ?: ""
+                password = findProperty("maven.password") ?: ""
+            }
+        }
     }
 }
 
-wrapper {
-    gradleVersion = '5.5.1'
+signing {
+    sign publishing.publications.mavenJava
 }
 
 jacoco {
-    toolVersion = "0.8.4"
+    toolVersion = "0.8.7"
 }
 
 jacocoTestReport {
-    reports.xml.enabled = true
-    reports.html.enabled = false
-    reports.csv.enabled = false
+    reports.xml.required = true
+    reports.html.required = false
+    reports.csv.required = false
 }
 
 // Test Logging - https://stackoverflow.com/a/42425815/2623314

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### Description of the pull request

Update gradle wrapper from 5.0 to 7.3.

This required:
* Migrating from the deprecated maven plugin to maven-publish
* Removing the deprecated jcenter repository
* Replacing deprecated gradle features with equivalent modern ones (plugin declarations, dependency specifications, ...)
* Updating jacoco

#### Why is the change necessary?

Gradle 5 conflicted with newer versions of the jdk, which prevented us from using them locally for development.

----

CC @pusher/mobile 
