### PR TITLE
Upgrade jacoco to 0.8.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -188,7 +188,7 @@ signing {
 }
 
 jacoco {
-    toolVersion = "0.8.7"
+    toolVersion = "0.8.8"
 }
 
 jacocoTestReport {


### PR DESCRIPTION
### Description of the pull request

Upgrade jacoco to 0.8.8.

#### Why is the change necessary?

It adds support for java 17 and 18, making it possible to test with them locally.

----

CC @pusher/mobile 
