### PR TITLE
Introduce UserAuthenticator and rename Authorizer to ChannelAuthorizer

### DIFF
--- a/src/main/java/com/pusher/client/AuthenticationFailureException.java
+++ b/src/main/java/com/pusher/client/AuthenticationFailureException.java
@@ -1,0 +1,27 @@
+package com.pusher.client;
+
+/**
+ * Used to indicate an authentication failure.
+ *
+ * @see com.pusher.client.UserAuthenticator
+ */
+public class AuthenticationFailureException extends RuntimeException {
+
+    private static final long serialVersionUID = -7208133561904200801L;
+
+    public AuthenticationFailureException() {
+        super();
+    }
+
+    public AuthenticationFailureException(final String msg) {
+        super(msg);
+    }
+
+    public AuthenticationFailureException(final Exception cause) {
+        super(cause);
+    }
+
+    public AuthenticationFailureException(final String msg, final Exception cause) {
+        super(msg, cause);
+    }
+}

--- a/src/main/java/com/pusher/client/AuthorizationFailureException.java
+++ b/src/main/java/com/pusher/client/AuthorizationFailureException.java
@@ -3,7 +3,7 @@ package com.pusher.client;
 /**
  * Used to indicate an authorization failure.
  *
- * @see com.pusher.client.Authorizer
+ * @see com.pusher.client.ChannelAuthorizer
  */
 public class AuthorizationFailureException extends RuntimeException {
 

--- a/src/main/java/com/pusher/client/Authorizer.java
+++ b/src/main/java/com/pusher/client/Authorizer.java
@@ -1,30 +1,9 @@
 package com.pusher.client;
 
-/**
- * Subscriptions to {@link com.pusher.client.channel.PrivateChannel Private} and
- * {@link com.pusher.client.channel.PresenceChannel presence} channels need to
- * be authorized. This interface provides an {@link #authorize} as a mechanism
- * for doing this.
- *
- * <p>
- * See the {@link com.pusher.client.util.HttpAuthorizer HttpAuthorizer} as an
- * example.
- * </p>
- */
-public interface Authorizer {
 
-    /**
-     * Called when a channel is to be authenticated.
-     *
-     * @param channelName
-     *            The name of the channel to be authenticated.
-     * @param socketId
-     *            A unique socket connection ID to be used with the
-     *            authentication. This uniquely identifies the connection that
-     *            the subscription is being authenticated for.
-     * @return An authentication token.
-     * @throws AuthorizationFailureException
-     *             if the authentication fails.
-     */
-    String authorize(String channelName, String socketId) throws AuthorizationFailureException;
-}
+/**
+ * @deprecated
+ * Please use {@link com.pusher.client.ChannelAuthorizer}
+ */
+@Deprecated
+public interface Authorizer extends ChannelAuthorizer {}

--- a/src/main/java/com/pusher/client/ChannelAuthorizer.java
+++ b/src/main/java/com/pusher/client/ChannelAuthorizer.java
@@ -1,0 +1,30 @@
+package com.pusher.client;
+
+/**
+ * Subscriptions to {@link com.pusher.client.channel.PrivateChannel Private} and
+ * {@link com.pusher.client.channel.PresenceChannel presence} channels need to
+ * be authorized. This interface provides an {@link #authorize} method as a mechanism
+ * for doing this.
+ *
+ * <p>
+ * See the {@link com.pusher.client.util.HttpChannelAuthorizer HttpChannelAuthorizer} as an
+ * example.
+ * </p>
+ */
+public interface ChannelAuthorizer {
+
+    /**
+     * Called when a channel subscription is to be authorized.
+     *
+     * @param channelName
+     *            The name of the channel to be authorized.
+     * @param socketId
+     *            A unique socket connection ID to be used with the
+     *            authorization. This uniquely identifies the connection that
+     *            the subscription is being authorized for.
+     * @return A channel authorization token.
+     * @throws AuthorizationFailureException
+     *             if the authorization fails.
+     */
+    String authorize(String channelName, String socketId) throws AuthorizationFailureException;
+}

--- a/src/main/java/com/pusher/client/Pusher.java
+++ b/src/main/java/com/pusher/client/Pusher.java
@@ -48,13 +48,13 @@ public class Pusher implements Client {
      *
      * <p>
      * Note that if you use this constructor you will not be able to subscribe
-     * to private or presence channels because no {@link Authorizer} has been
+     * to private or presence channels because no {@link ChannelAuthorizer} has been
      * set. If you want to use private or presence channels:
      * <ul>
-     * <li>Create an implementation of the {@link Authorizer} interface, or use
-     * the {@link com.pusher.client.util.HttpAuthorizer} provided.</li>
+     * <li>Create an implementation of the {@link ChannelAuthorizer} interface, or use
+     * the {@link com.pusher.client.util.HttpChannelAuthorizer} provided.</li>
      * <li>Create an instance of {@link PusherOptions} and set the authorizer on
-     * it by calling {@link PusherOptions#setAuthorizer(Authorizer)}.</li>
+     * it by calling {@link PusherOptions#setChannelAuthorizer(ChannelAuthorizer)}.</li>
      * <li>Use the {@link #Pusher(String, PusherOptions)} constructor to create
      * an instance of Pusher.</li>
      * </ul>
@@ -257,7 +257,7 @@ public class Pusher implements Client {
      * @return A new {@link com.pusher.client.channel.PrivateChannel}
      *         representing the subscription.
      * @throws IllegalStateException
-     *             if a {@link com.pusher.client.Authorizer} has not been set
+     *             if a {@link com.pusher.client.ChannelAuthorizer} has not been set
      *             for the {@link Pusher} instance via
      *             {@link #Pusher(String, PusherOptions)}.
      */
@@ -273,15 +273,15 @@ public class Pusher implements Client {
      * @param listener A listener to be informed of both Pusher channel protocol events and subscription data events.
      * @param eventNames An optional list of names of events to be bound to on the channel. The equivalent of calling {@link com.pusher.client.channel.Channel#bind(String, SubscriptionEventListener)} one or more times.
      * @return A new {@link com.pusher.client.channel.PrivateChannel} representing the subscription.
-     * @throws IllegalStateException if a {@link com.pusher.client.Authorizer} has not been set for the {@link Pusher} instance via {@link #Pusher(String, PusherOptions)}.
+     * @throws IllegalStateException if a {@link com.pusher.client.ChannelAuthorizer} has not been set for the {@link Pusher} instance via {@link #Pusher(String, PusherOptions)}.
      */
     public PrivateChannel subscribePrivate(final String channelName, final PrivateChannelEventListener listener,
             final String... eventNames) {
 
-        throwExceptionIfNoAuthorizerHasBeenSet();
+        throwExceptionIfNoChannelAuthorizerHasBeenSet();
 
         final PrivateChannelImpl channel = factory.newPrivateChannel(connection, channelName,
-                pusherOptions.getAuthorizer());
+                pusherOptions.getChannelAuthorizer());
         channelManager.subscribeTo(channel, listener, eventNames);
 
         return channel;
@@ -301,7 +301,7 @@ public class Pusher implements Client {
      *                   one or more times.
      * @return A new {@link com.pusher.client.channel.PrivateEncryptedChannel} representing
      *         the subscription.
-     * @throws IllegalStateException if a {@link com.pusher.client.Authorizer} has not been set for
+     * @throws IllegalStateException if a {@link com.pusher.client.ChannelAuthorizer} has not been set for
      *         the {@link Pusher} instance via {@link #Pusher(String, PusherOptions)}.
      */
     public PrivateEncryptedChannel subscribePrivateEncrypted(
@@ -309,10 +309,10 @@ public class Pusher implements Client {
             final PrivateEncryptedChannelEventListener listener,
             final String... eventNames) {
 
-        throwExceptionIfNoAuthorizerHasBeenSet();
+        throwExceptionIfNoChannelAuthorizerHasBeenSet();
 
         final PrivateEncryptedChannelImpl channel = factory.newPrivateEncryptedChannel(
-                        connection, channelName, pusherOptions.getAuthorizer());
+                        connection, channelName, pusherOptions.getChannelAuthorizer());
         channelManager.subscribeTo(channel, listener, eventNames);
 
         return channel;
@@ -328,7 +328,7 @@ public class Pusher implements Client {
      * @return A new {@link com.pusher.client.channel.PresenceChannel}
      *         representing the subscription.
      * @throws IllegalStateException
-     *             if a {@link com.pusher.client.Authorizer} has not been set
+     *             if a {@link com.pusher.client.ChannelAuthorizer} has not been set
      *             for the {@link Pusher} instance via
      *             {@link #Pusher(String, PusherOptions)}.
      */
@@ -344,15 +344,15 @@ public class Pusher implements Client {
      * @param listener A listener to be informed of Pusher channel protocol, including presence-specific events, and subscription data events.
      * @param eventNames An optional list of names of events to be bound to on the channel. The equivalent of calling {@link com.pusher.client.channel.Channel#bind(String, SubscriptionEventListener)} one or more times.
      * @return A new {@link com.pusher.client.channel.PresenceChannel} representing the subscription.
-     * @throws IllegalStateException if a {@link com.pusher.client.Authorizer} has not been set for the {@link Pusher} instance via {@link #Pusher(String, PusherOptions)}.
+     * @throws IllegalStateException if a {@link com.pusher.client.ChannelAuthorizer} has not been set for the {@link Pusher} instance via {@link #Pusher(String, PusherOptions)}.
      */
     public PresenceChannel subscribePresence(final String channelName, final PresenceChannelEventListener listener,
             final String... eventNames) {
 
-        throwExceptionIfNoAuthorizerHasBeenSet();
+        throwExceptionIfNoChannelAuthorizerHasBeenSet();
 
         final PresenceChannelImpl channel = factory.newPresenceChannel(connection, channelName,
-                pusherOptions.getAuthorizer());
+                pusherOptions.getChannelAuthorizer());
         channelManager.subscribeTo(channel, listener, eventNames);
 
         return channel;
@@ -371,10 +371,10 @@ public class Pusher implements Client {
 
     /* implementation detail */
 
-    private void throwExceptionIfNoAuthorizerHasBeenSet() {
-        if (pusherOptions.getAuthorizer() == null) {
+    private void throwExceptionIfNoChannelAuthorizerHasBeenSet() {
+        if (pusherOptions.getChannelAuthorizer() == null) {
             throw new IllegalStateException(
-                    "Cannot subscribe to a private or presence channel because no Authorizer has been set. Call PusherOptions.setAuthorizer() before connecting to Pusher");
+                    "Cannot subscribe to a private or presence channel because no ChannelAuthorizer has been set. Call PusherOptions.setChannelAuthorizer() before connecting to Pusher");
         }
     }
 

--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -37,6 +37,8 @@ public class PusherOptions {
     private boolean useTLS = true;
     private long activityTimeout = DEFAULT_ACTIVITY_TIMEOUT;
     private long pongTimeout = DEFAULT_PONG_TIMEOUT;
+    private UserAuthenticator userAuthenticator;
+    private ChannelAuthorizer channelAuthorizer;
     private Authorizer authorizer;
     private Proxy proxy = Proxy.NO_PROXY;
     private int maxReconnectionAttempts = MAX_RECONNECTION_ATTEMPTS;
@@ -80,26 +82,66 @@ public class PusherOptions {
     }
 
     /**
-     * Gets the authorizer to be used when authenticating private and presence
+     * Gets the user authenticator to be used when signing in.
+     *
+     * @return the user authenticator
+     */
+    public UserAuthenticator getUserAuthenticator() {
+        return userAuthenticator;
+    }
+
+    /**
+     * Sets the user authenticator to be used when signing in.
+     *
+     * @param userAuthenticator
+     *            The user authenticator to be used.
+     * @return this, for chaining
+     */
+    public PusherOptions setUserAuthenticator(final UserAuthenticator userAuthenticator) {
+        this.userAuthenticator = userAuthenticator;
+        return this;
+    }
+
+    /**
+     * Gets the channel authorizer to be used when authorizing private and presence
      * channels.
      *
-     * @return the authorizer
+     * @return the channel authorizer
      */
+    public ChannelAuthorizer getChannelAuthorizer() {
+        return channelAuthorizer;
+    }
+
+    /**
+     * Sets the channel authorizer to be used when authorizing private and presence
+     * channels.
+     *
+     * @param channelAuthorizer
+     *            The channel authorizer to be used.
+     * @return this, for chaining
+     */
+    public PusherOptions setChannelAuthorizer(final ChannelAuthorizer channelAuthorizer) {
+        this.channelAuthorizer = channelAuthorizer;
+        return this;
+    }
+
+    /**
+     * @deprecated
+     * Please use getChannelauthorizer
+     */
+    @Deprecated
     public Authorizer getAuthorizer() {
         return authorizer;
     }
 
     /**
-     * Sets the authorizer to be used when authenticating private and presence
-     * channels.
-     *
-     * @param authorizer
-     *            The authorizer to be used.
-     * @return this, for chaining
+     * @deprecated
+     * Please use setChannelauthorizer
      */
+    @Deprecated
     public PusherOptions setAuthorizer(final Authorizer authorizer) {
         this.authorizer = authorizer;
-        return this;
+        return setChannelAuthorizer(authorizer);
     }
 
     /**

--- a/src/main/java/com/pusher/client/UserAuthenticator.java
+++ b/src/main/java/com/pusher/client/UserAuthenticator.java
@@ -1,0 +1,27 @@
+package com.pusher.client;
+
+/**
+ * Sigining in as a User on a connection requires authentication.
+ * This interface provides an {@link #authenticate} method as a mechanism
+ * for doing this.
+ *
+ * <p>
+ * See the {@link com.pusher.client.util.HttpUserAuthenticator} as an
+ * example.
+ * </p>
+ */
+public interface UserAuthenticator {
+
+    /**
+     * Called when a user is to be authenticated.
+     *
+     * @param socketId
+     *            A unique socket connection ID to be used with the
+     *            authentication. This uniquely identifies the connection that
+     *            on which the user is being authenticated.
+     * @return A user authentication token.
+     * @throws AuthenticationFailureException
+     *            if the authentication fails.
+     */
+    String authenticate(String socketId) throws AuthenticationFailureException;
+}

--- a/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PresenceChannelImpl.java
@@ -3,7 +3,7 @@ package com.pusher.client.channel.impl;
 import com.google.gson.Gson;
 import com.google.gson.JsonSyntaxException;
 import com.pusher.client.AuthorizationFailureException;
-import com.pusher.client.Authorizer;
+import com.pusher.client.ChannelAuthorizer;
 import com.pusher.client.channel.ChannelEventListener;
 import com.pusher.client.channel.PresenceChannel;
 import com.pusher.client.channel.PresenceChannelEventListener;
@@ -34,8 +34,8 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
     private String myUserID;
 
     public PresenceChannelImpl(final InternalConnection connection, final String channelName,
-            final Authorizer authorizer, final Factory factory) {
-        super(connection, channelName, authorizer, factory);
+            final ChannelAuthorizer channelAuthorizer, final Factory factory) {
+        super(connection, channelName, channelAuthorizer, factory);
     }
 
     /* PresenceChannel implementation */
@@ -171,15 +171,15 @@ public class PresenceChannelImpl extends PrivateChannelImpl implements PresenceC
             ChannelData data = GSON.fromJson(channelDataString, ChannelData.class);
 
             if (data.getUserId() == null) {
-                throw new AuthorizationFailureException("Invalid response from Authorizer: no user_id key in channel_data object: " + channelDataString);
+                throw new AuthorizationFailureException("Invalid response from ChannelAuthorizer: no user_id key in channel_data object: " + channelDataString);
             }
 
             return data.getUserId();
 
         } catch (final JsonSyntaxException e) {
-            throw new AuthorizationFailureException("Invalid response from Authorizer: unable to parse channel_data object: " + channelDataString, e);
+            throw new AuthorizationFailureException("Invalid response from ChannelAuthorizer: unable to parse channel_data object: " + channelDataString, e);
         } catch (final NullPointerException e) {
-            throw new AuthorizationFailureException("Invalid response from Authorizer: no user_id key in channel_data object: " + channelDataString);
+            throw new AuthorizationFailureException("Invalid response from ChannelAuthorizer: no user_id key in channel_data object: " + channelDataString);
         }
 
     }

--- a/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PresenceChannelExampleApp.java
@@ -10,7 +10,7 @@ import com.pusher.client.channel.PresenceChannelEventListener;
 import com.pusher.client.channel.User;
 import com.pusher.client.connection.ConnectionEventListener;
 import com.pusher.client.connection.ConnectionStateChange;
-import com.pusher.client.util.HttpAuthorizer;
+import com.pusher.client.util.HttpChannelAuthorizer;
 
 /*
 This app demonstrates how to use Presence Channels.
@@ -32,7 +32,7 @@ public class PresenceChannelExampleApp {
     private String channelName = "my-channel";
     private String eventName = "my-event";
     private String cluster = "eu";
-    private String authorizationEndpoint = "http://localhost:3030/pusher/auth";
+    private String channelAuthorizationEndpoint = "http://localhost:3030/pusher/auth";
 
     private final PresenceChannel channel;
 
@@ -50,14 +50,14 @@ public class PresenceChannelExampleApp {
             case 1: channelsKey = args[0];
         }
 
-        // create a HttpAuthorizer that points to your authorization server
-        final HttpAuthorizer authorizer = new HttpAuthorizer(authorizationEndpoint);
+        // create a HttpChannelAuthorizer that points to your channel authorization server
+        final HttpChannelAuthorizer channelAuthorizer = new HttpChannelAuthorizer(channelAuthorizationEndpoint);
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
                 .setUseTLS(true)
                 .setCluster(cluster)
-                .setAuthorizer(authorizer);
+                .setChannelAuthorizer(channelAuthorizer);
         Pusher pusher = new Pusher(channelsKey, options);
 
         // set up a ConnectionEventListener to listen for connection changes to Pusher
@@ -95,7 +95,7 @@ public class PresenceChannelExampleApp {
             @Override
             public void onAuthenticationFailure(String message, Exception e) {
                 System.out.println(String.format(
-                        "Authentication failure due to [%s], exception was [%s]", message, e));
+                        "Authorization failure due to [%s], exception was [%s]", message, e));
             }
 
             @Override

--- a/src/main/java/com/pusher/client/example/PrivateChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateChannelExampleApp.java
@@ -7,7 +7,7 @@ import com.pusher.client.channel.PrivateChannel;
 import com.pusher.client.channel.PrivateChannelEventListener;
 import com.pusher.client.connection.ConnectionEventListener;
 import com.pusher.client.connection.ConnectionStateChange;
-import com.pusher.client.util.HttpAuthorizer;
+import com.pusher.client.util.HttpChannelAuthorizer;
 
 /*
 This app demonstrates how to use Private Channels.
@@ -29,7 +29,7 @@ public class PrivateChannelExampleApp {
     private String channelName = "my-channel";
     private String eventName = "my-event";
     private String cluster = "eu";
-    private String authorizationEndpoint = "http://localhost:3030/pusher/auth";
+    private String channelAuthorizationEndpoint = "http://localhost:3030/pusher/auth";
 
     private final PrivateChannel channel;
 
@@ -47,14 +47,14 @@ public class PrivateChannelExampleApp {
             case 1: channelsKey = args[0];
         }
 
-        // create a HttpAuthorizer that points to your authorization server
-        final HttpAuthorizer authorizer = new HttpAuthorizer(authorizationEndpoint);
+        // create a HttpChannelAuthorizer that points to your channel authorization server
+        final HttpChannelAuthorizer channelAuthorizer = new HttpChannelAuthorizer(channelAuthorizationEndpoint);
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
                 .setUseTLS(true)
                 .setCluster(cluster)
-                .setAuthorizer(authorizer);
+                .setChannelAuthorizer(channelAuthorizer);
         Pusher pusher = new Pusher(channelsKey, options);
 
         // set up a ConnectionEventListener to listen for connection changes to Pusher
@@ -92,7 +92,7 @@ public class PrivateChannelExampleApp {
             @Override
             public void onAuthenticationFailure(String message, Exception e) {
                 System.out.println(String.format(
-                        "Authentication failure due to [%s], exception was [%s]", message, e));
+                        "Authorization failure due to [%s], exception was [%s]", message, e));
             }
         };
 

--- a/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
+++ b/src/main/java/com/pusher/client/example/PrivateEncryptedChannelExampleApp.java
@@ -7,7 +7,7 @@ import com.pusher.client.channel.PrivateEncryptedChannelEventListener;
 import com.pusher.client.channel.PusherEvent;
 import com.pusher.client.connection.ConnectionEventListener;
 import com.pusher.client.connection.ConnectionStateChange;
-import com.pusher.client.util.HttpAuthorizer;
+import com.pusher.client.util.HttpChannelAuthorizer;
 
 /*
 This app demonstrates how to use Private Encrypted Channels.
@@ -34,7 +34,7 @@ public class PrivateEncryptedChannelExampleApp {
     private String channelName = "private-encrypted-channel";
     private String eventName = "my-event";
     private String cluster = "eu";
-    private String authorizationEndpoint = "http://localhost:3030/pusher/auth";
+    private String channelAuthorizationEndpoint = "http://localhost:3030/pusher/auth";
 
     private PrivateEncryptedChannel channel;
 
@@ -52,13 +52,13 @@ public class PrivateEncryptedChannelExampleApp {
             case 1: channelsKey = args[0];
         }
 
-        // create a HttpAuthorizer that points to your authorization server
-        final HttpAuthorizer authorizer = new HttpAuthorizer(authorizationEndpoint);
+        // create a HttpChannelAuthorizer that points to your channel authorization server
+        final HttpChannelAuthorizer channelAuthorizer = new HttpChannelAuthorizer(channelAuthorizationEndpoint);
 
         // configure your Pusher connection with the options you want
         final PusherOptions options = new PusherOptions()
                 .setCluster(cluster)
-                .setAuthorizer(authorizer)
+                .setChannelAuthorizer(channelAuthorizer)
                 .setUseTLS(true);
         Pusher pusher = new Pusher(channelsKey, options);
 
@@ -98,7 +98,7 @@ public class PrivateEncryptedChannelExampleApp {
             @Override
             public void onAuthenticationFailure(String message, Exception e) {
                 System.out.println(String.format(
-                        "Authentication failure due to [%s], exception was [%s]", message, e));
+                        "Authorization failure due to [%s], exception was [%s]", message, e));
             }
 
             @Override

--- a/src/main/java/com/pusher/client/util/BaseHttpAuthClient.java
+++ b/src/main/java/com/pusher/client/util/BaseHttpAuthClient.java
@@ -1,0 +1,146 @@
+package com.pusher.client.util;
+
+import java.io.BufferedReader;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+import javax.net.ssl.HttpsURLConnection;
+
+/**
+ * Base class for {@link com.pusher.client.util.HttpChannelAuthorizer} and {@link com.pusher.client.util.HttpUserAuthenticator}
+ *
+ */
+
+abstract class BaseHttpAuthClient {
+
+    private final URL endPoint;
+    private Map<String, String> mHeaders = new HashMap<String, String>();
+    protected ConnectionFactory mConnectionFactory = null;
+
+    /**
+     * Creates a new auth client.
+     *
+     * @param endPoint
+     *            The endpoint to be called when authorizing or authenticating.
+     */
+    public BaseHttpAuthClient(final String endPoint) {
+        try {
+            this.endPoint = new URL(endPoint);
+            this.mConnectionFactory = new UrlEncodedConnectionFactory();
+        }
+        catch (final MalformedURLException e) {
+            throw new IllegalArgumentException("Could not parse channel authorization end point into a valid URL", e);
+        }
+    }
+
+    /**
+     * Creates a new auth client.
+     *
+     * @param endPoint The endpoint to be called when authorizing or authenticating.
+     * @param connectionFactory a custom connection factory to be used for building the connection
+     */
+    public BaseHttpAuthClient(final String endPoint, final ConnectionFactory connectionFactory) {
+        try {
+            this.endPoint = new URL(endPoint);
+            this.mConnectionFactory = connectionFactory;
+        } catch (final MalformedURLException e) {
+            throw new IllegalArgumentException("Could not parse channel authorization end point into a valid URL", e);
+        }
+    }
+
+    /**
+     * Set additional headers to be sent as part of the request.
+     *
+     * @param headers A map of headers
+     */
+    public void setHeaders(final Map<String, String> headers) {
+        mHeaders = headers;
+    }
+
+    /**
+     * Identifies if the HTTP request will be sent over HTTPS.
+     * @return true if the endpoint protocol is 'https'
+     */
+    public Boolean isSSL() {
+        return endPoint.getProtocol().equals("https");
+    }
+
+    /**
+     * Performs an HTTP request to the endpoint provided on construction.
+     *
+     * The request shall include the headers and parameters provided by
+     * the connectionFactory.
+     *
+     * Child classes must provide the connection parameters to the
+     * connectionFactory before calling this method.
+     *
+     * @return HTTP request response body
+     */
+    protected String performAuthRequest() {
+        try {
+            String body = mConnectionFactory.getBody();
+
+            final HashMap<String, String> defaultHeaders = new HashMap<String, String>();
+            defaultHeaders.put("Content-Type", mConnectionFactory.getContentType());
+            defaultHeaders.put("charset", mConnectionFactory.getCharset());
+
+            HttpURLConnection connection;
+            if (isSSL()) {
+                connection = (HttpsURLConnection)endPoint.openConnection();
+            }
+            else {
+                connection = (HttpURLConnection)endPoint.openConnection();
+            }
+            connection.setDoOutput(true);
+            connection.setDoInput(true);
+            connection.setInstanceFollowRedirects(false);
+            connection.setRequestMethod("POST");
+
+            // Add in the user defined headers
+            defaultHeaders.putAll(mHeaders);
+            // Add in the Content-Length, so it can't be overwritten by mHeaders
+            defaultHeaders.put("Content-Length","" + body.getBytes().length);
+
+            for (final String headerName : defaultHeaders.keySet()) {
+                final String headerValue = defaultHeaders.get(headerName);
+                connection.setRequestProperty(headerName, headerValue);
+            }
+
+            connection.setUseCaches(false);
+
+            // Send request
+            final DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
+            wr.writeBytes(body);
+            wr.flush();
+            wr.close();
+
+            // Read response
+            final InputStream is = connection.getInputStream();
+            final BufferedReader rd = new BufferedReader(new InputStreamReader(is));
+            String line;
+            final StringBuffer response = new StringBuffer();
+            while ((line = rd.readLine()) != null) {
+                response.append(line);
+            }
+            rd.close();
+
+            final int responseHttpStatus = connection.getResponseCode();
+            if (responseHttpStatus != 200 && responseHttpStatus != 201) {
+                throw authFailureException(response.toString());
+            }
+
+            return response.toString();
+        } catch (final IOException e) {
+            throw authFailureException(e);
+        }
+    }
+
+    abstract protected RuntimeException authFailureException(String msg);
+    abstract protected RuntimeException authFailureException(IOException e);
+}

--- a/src/main/java/com/pusher/client/util/ConnectionFactory.java
+++ b/src/main/java/com/pusher/client/util/ConnectionFactory.java
@@ -2,7 +2,7 @@ package com.pusher.client.util;
 
 /**
  * Abstract factory to be used for
- * building HttpAuthorizer connections
+ * building HttpChannelAuthorizer connections
  */
 public abstract class ConnectionFactory {
     private String channelName;

--- a/src/main/java/com/pusher/client/util/Factory.java
+++ b/src/main/java/com/pusher/client/util/Factory.java
@@ -10,8 +10,10 @@ import java.util.concurrent.ThreadFactory;
 
 import javax.net.ssl.SSLException;
 
-import com.pusher.client.Authorizer;
+import com.pusher.client.ChannelAuthorizer;
 import com.pusher.client.PusherOptions;
+import com.pusher.client.UserAuthenticator;
+import com.pusher.client.Pusher;
 import com.pusher.client.channel.impl.ChannelImpl;
 import com.pusher.client.channel.impl.ChannelManager;
 import com.pusher.client.channel.impl.PrivateEncryptedChannelImpl;
@@ -84,21 +86,21 @@ public class Factory {
     }
 
     public PrivateChannelImpl newPrivateChannel(final InternalConnection connection, final String channelName,
-            final Authorizer authorizer) {
-        return new PrivateChannelImpl(connection, channelName, authorizer, this);
+            final ChannelAuthorizer channelAuthorizer) {
+        return new PrivateChannelImpl(connection, channelName, channelAuthorizer, this);
     }
 
     public PrivateEncryptedChannelImpl newPrivateEncryptedChannel(
             final InternalConnection connection,
             final String channelName,
-            final Authorizer authorizer) {
-        return new PrivateEncryptedChannelImpl(connection, channelName, authorizer, this,
+            final ChannelAuthorizer channelAuthorizer) {
+        return new PrivateEncryptedChannelImpl(connection, channelName, channelAuthorizer, this,
                 new SecretBoxOpenerFactory());
     }
 
     public PresenceChannelImpl newPresenceChannel(final InternalConnection connection, final String channelName,
-            final Authorizer authorizer) {
-        return new PresenceChannelImpl(connection, channelName, authorizer, this);
+            final ChannelAuthorizer channelAuthorizer) {
+        return new PresenceChannelImpl(connection, channelName, channelAuthorizer, this);
     }
 
     public synchronized ChannelManager getChannelManager() {

--- a/src/main/java/com/pusher/client/util/HttpAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpAuthorizer.java
@@ -15,26 +15,11 @@ import java.util.Map;
 import javax.net.ssl.HttpsURLConnection;
 
 /**
- * Used to authenticate a {@link com.pusher.client.channel.PrivateChannel
- * private} or {@link com.pusher.client.channel.PresenceChannel presence}
- * channel subscription.
- *
- * <p>
- * Makes an HTTP request to a defined HTTP endpoint. Expects an authentication
- * token to be returned.
- * </p>
- *
- * <p>
- * For more information see the <a
- * href="http://pusher.com/docs/authenticating_users">Authenticating Users
- * documentation</a>.
+ * @deprecated
+ * Please use {@link com.pusher.client.util.HttpChannelAuthorizer}
  */
-public class HttpAuthorizer implements Authorizer {
-
-    private final URL endPoint;
-    private Map<String, String> mHeaders = new HashMap<String, String>();
-    private ConnectionFactory mConnectionFactory = null;
-
+@Deprecated
+public class HttpAuthorizer extends HttpChannelAuthorizer implements Authorizer {
     /**
      * Creates a new authorizer.
      *
@@ -42,13 +27,7 @@ public class HttpAuthorizer implements Authorizer {
      *            The endpoint to be called when authenticating.
      */
     public HttpAuthorizer(final String endPoint) {
-        try {
-            this.endPoint = new URL(endPoint);
-            this.mConnectionFactory = new UrlEncodedConnectionFactory();
-        }
-        catch (final MalformedURLException e) {
-            throw new IllegalArgumentException("Could not parse authentication end point into a valid URL", e);
-        }
+        super(endPoint);
     }
 
     /**
@@ -58,92 +37,6 @@ public class HttpAuthorizer implements Authorizer {
      * @param connectionFactory a custom connection factory to be used for building the connection
      */
     public HttpAuthorizer(final String endPoint, final ConnectionFactory connectionFactory) {
-        try {
-            this.endPoint = new URL(endPoint);
-            this.mConnectionFactory = connectionFactory;
-        } catch (final MalformedURLException e) {
-            throw new IllegalArgumentException("Could not parse authentication end point into a valid URL", e);
-        }
-    }
-
-    /**
-     * Set additional headers to be sent as part of the request.
-     *
-     * @param headers A map of headers
-     */
-    public void setHeaders(final Map<String, String> headers) {
-        mHeaders = headers;
-    }
-
-    /**
-     * Identifies if the HTTP request will be sent over HTTPS.
-     * @return true if the endpoint protocol is 'https'
-     */
-    public Boolean isSSL() {
-        return endPoint.getProtocol().equals("https");
-    }
-
-    @Override
-    public String authorize(final String channelName, final String socketId) throws AuthorizationFailureException {
-        try {
-            mConnectionFactory.setChannelName(channelName);
-            mConnectionFactory.setSocketId(socketId);
-            String body = mConnectionFactory.getBody();
-
-            final HashMap<String, String> defaultHeaders = new HashMap<String, String>();
-            defaultHeaders.put("Content-Type", mConnectionFactory.getContentType());
-            defaultHeaders.put("charset", mConnectionFactory.getCharset());
-
-            HttpURLConnection connection;
-            if (isSSL()) {
-                connection = (HttpsURLConnection)endPoint.openConnection();
-            }
-            else {
-                connection = (HttpURLConnection)endPoint.openConnection();
-            }
-            connection.setDoOutput(true);
-            connection.setDoInput(true);
-            connection.setInstanceFollowRedirects(false);
-            connection.setRequestMethod("POST");
-
-            // Add in the user defined headers
-            defaultHeaders.putAll(mHeaders);
-            // Add in the Content-Length, so it can't be overwritten by mHeaders
-            defaultHeaders.put("Content-Length","" + body.getBytes().length);
-            
-            for (final String headerName : defaultHeaders.keySet()) {
-                final String headerValue = defaultHeaders.get(headerName);
-                connection.setRequestProperty(headerName, headerValue);
-            }
-
-            connection.setUseCaches(false);
-
-            // Send request
-            final DataOutputStream wr = new DataOutputStream(connection.getOutputStream());
-            wr.writeBytes(body);
-            wr.flush();
-            wr.close();
-
-            // Read response
-            final InputStream is = connection.getInputStream();
-            final BufferedReader rd = new BufferedReader(new InputStreamReader(is));
-            String line;
-            final StringBuffer response = new StringBuffer();
-            while ((line = rd.readLine()) != null) {
-                response.append(line);
-            }
-            rd.close();
-
-            final int responseHttpStatus = connection.getResponseCode();
-            if (responseHttpStatus != 200 && responseHttpStatus != 201) {
-                throw new AuthorizationFailureException(response.toString());
-            }
-
-            return response.toString();
-
-        }
-        catch (final IOException e) {
-            throw new AuthorizationFailureException(e);
-        }
+        super(endPoint, connectionFactory);
     }
 }

--- a/src/main/java/com/pusher/client/util/HttpChannelAuthorizer.java
+++ b/src/main/java/com/pusher/client/util/HttpChannelAuthorizer.java
@@ -1,0 +1,61 @@
+package com.pusher.client.util;
+
+import com.pusher.client.AuthorizationFailureException;
+import com.pusher.client.ChannelAuthorizer;
+import java.io.IOException;
+
+/**
+ * Used to authorize a {@link com.pusher.client.channel.PrivateChannel
+ * private} or {@link com.pusher.client.channel.PresenceChannel presence}
+ * channel subscription.
+ *
+ * <p>
+ * Makes an HTTP request to a defined HTTP endpoint. Expects a channel authorization
+ * token to be returned.
+ * </p>
+ *
+ * <p>
+ * For more information see the <a
+ * href="http://pusher.com/docs/authorizing_users">Authorizing Users
+ * documentation</a>.
+ */
+
+public class HttpChannelAuthorizer extends BaseHttpAuthClient implements ChannelAuthorizer {
+
+    /**
+     * Creates a new channel authorizer.
+     *
+     * @param endPoint
+     *            The endpoint to be called when authorizing.
+     */
+    public HttpChannelAuthorizer(final String endPoint) {
+        super(endPoint);
+    }
+
+    /**
+     * Creates a new channel authorizer.
+     *
+     * @param endPoint The endpoint to be called when authorizing.
+     * @param connectionFactory a custom connection factory to be used for building the connection
+     */
+    public HttpChannelAuthorizer(final String endPoint, final ConnectionFactory connectionFactory) {
+        super(endPoint, connectionFactory);
+    }
+
+    @Override
+    public String authorize(final String channelName, final String socketId) throws AuthorizationFailureException {
+        mConnectionFactory.setChannelName(channelName);
+        mConnectionFactory.setSocketId(socketId);
+        return performAuthRequest();
+    }
+
+    @Override
+    protected RuntimeException authFailureException(String msg) {
+        return new AuthorizationFailureException(msg);
+    }
+
+    @Override
+    protected RuntimeException authFailureException(IOException e) {
+        return new AuthorizationFailureException(e);
+    }
+}

--- a/src/main/java/com/pusher/client/util/HttpUserAuthenticator.java
+++ b/src/main/java/com/pusher/client/util/HttpUserAuthenticator.java
@@ -1,0 +1,57 @@
+package com.pusher.client.util;
+
+import com.pusher.client.AuthenticationFailureException;
+import com.pusher.client.UserAuthenticator;
+import java.io.IOException;
+
+/**
+ * Used to authenticate the user when signing in on a Pusher Channels connection.
+ *
+ * <p>
+ * Makes an HTTP request to a defined HTTP endpoint. Expects a user authentication
+ * token to be returned.
+ * </p>
+ *
+ * <p>
+ * For more information see the <a
+ * href="http://pusher.com/docs/authenticating_users">Authenticating Users
+ * documentation</a>.
+ */
+public class HttpUserAuthenticator extends BaseHttpAuthClient implements UserAuthenticator {
+
+    /**
+     * Creates a new user authenticator.
+     *
+     * @param endPoint
+     *            The endpoint to be called when authenticating.
+     */
+    public HttpUserAuthenticator(final String endPoint) {
+        super(endPoint);
+    }
+
+    /**
+     * Creates a new user authenticator.
+     *
+     * @param endPoint The endpoint to be called when authenticating.
+     * @param connectionFactory a custom connection factory to be used for building the connection
+     */
+    public HttpUserAuthenticator(final String endPoint, final ConnectionFactory connectionFactory) {
+        super(endPoint, connectionFactory);
+    }
+
+    @Override
+    public String authenticate(final String socketId) throws AuthenticationFailureException {
+        mConnectionFactory.setSocketId(socketId);
+        return performAuthRequest();
+    }
+
+    @Override
+    protected RuntimeException authFailureException(String msg) {
+        return new AuthenticationFailureException(msg);
+    }
+
+    @Override
+    protected RuntimeException authFailureException(IOException e) {
+        return new AuthenticationFailureException(e);
+    }
+}

--- a/src/main/java/com/pusher/client/util/UrlEncodedConnectionFactory.java
+++ b/src/main/java/com/pusher/client/util/UrlEncodedConnectionFactory.java
@@ -8,7 +8,7 @@ import java.util.Map;
 /**
  * Form URL-Encoded Connection Factory
  *
- * Allows HttpAuthorizer to write URL parameters to the connection
+ * Allows HttpChannelAuthorizer to write URL parameters to the connection
  */
 public class UrlEncodedConnectionFactory extends ConnectionFactory {
 
@@ -42,8 +42,10 @@ public class UrlEncodedConnectionFactory extends ConnectionFactory {
     public String getBody() {
         final StringBuffer urlParameters = new StringBuffer();
         try {
-            urlParameters.append("channel_name=").append(URLEncoder.encode(getChannelName(), getCharset()));
-            urlParameters.append("&socket_id=").append(URLEncoder.encode(getSocketId(), getCharset()));
+            urlParameters.append("socket_id=").append(URLEncoder.encode(getSocketId(), getCharset()));
+            if (getChannelName() != null) {
+                urlParameters.append("&channel_name=").append(URLEncoder.encode(getChannelName(), getCharset()));
+            }
 
             // Adding extra parameters supplied to be added to query string.
             for (final String parameterName : mQueryStringParameters.keySet()) {

--- a/src/main/java/com/pusher/client/util/package-info.java
+++ b/src/main/java/com/pusher/client/util/package-info.java
@@ -2,9 +2,8 @@
  * Contains helper classes.
  *
  * <ul>
- *     <li>{@link com.pusher.client.util.HttpAuthorizer HttpAuthorizer} for authenticating against an HTTP endpoint when subscribing to
+ *     <li>{@link com.pusher.client.util.HttpChannelAuthorizer HttpChannelAuthorizer} for authorizing against an HTTP endpoint when subscribing to
  * {@link com.pusher.client.channel.PrivateChannel private} or {@link com.pusher.client.channel.PresenceChannel presence} channels.</li>
  * </ul>
  */
 package com.pusher.client.util;
-

--- a/src/test/java/com/pusher/client/EndToEndTest.java
+++ b/src/test/java/com/pusher/client/EndToEndTest.java
@@ -46,7 +46,7 @@ public class EndToEndTest {
 
     private static final Proxy proxy = Proxy.NO_PROXY;
 
-    private @Mock Authorizer mockAuthorizer;
+    private @Mock ChannelAuthorizer mockChannelAuthorizer;
     private @Mock ConnectionEventListener mockConnectionEventListener;
     private @Mock ServerHandshake mockServerHandshake;
     private @Mock Factory factory;
@@ -57,7 +57,7 @@ public class EndToEndTest {
 
     @Before
     public void setUp() throws Exception {
-        pusherOptions = new PusherOptions().setAuthorizer(mockAuthorizer).setUseTLS(false);
+        pusherOptions = new PusherOptions().setChannelAuthorizer(mockChannelAuthorizer).setUseTLS(false);
 
         connection = new WebSocketConnection(pusherOptions.buildUrl(API_KEY), ACTIVITY_TIMEOUT, PONG_TIMEOUT, pusherOptions.getMaxReconnectionAttempts(),
                 pusherOptions.getMaxReconnectGapInSeconds(), proxy, factory);
@@ -99,7 +99,7 @@ public class EndToEndTest {
                 .thenCallRealMethod();
         when(factory.newPublicChannel(anyString())).thenCallRealMethod();
 
-        when(mockAuthorizer.authorize(anyString(), anyString())).thenReturn("{\"auth\":\"" + AUTH_KEY + "\"}");
+        when(mockChannelAuthorizer.authorize(anyString(), anyString())).thenReturn("{\"auth\":\"" + AUTH_KEY + "\"}");
 
         pusher = new Pusher(API_KEY, pusherOptions, factory);
     }
@@ -134,20 +134,20 @@ public class EndToEndTest {
     public void testForQueuedSubscriptionsAuthorizerIsNotCalledUntilTimeToSubscribe() {
 
         pusher.subscribePrivate(PRIVATE_CHANNEL_NAME);
-        verify(mockAuthorizer, never()).authorize(anyString(), anyString());
+        verify(mockChannelAuthorizer, never()).authorize(anyString(), anyString());
 
         establishConnection();
-        verify(mockAuthorizer).authorize(eq(PRIVATE_CHANNEL_NAME), anyString());
+        verify(mockChannelAuthorizer).authorize(eq(PRIVATE_CHANNEL_NAME), anyString());
     }
 
     @Test
     public void testSubscriptionsAreResubscribedWithFreshAuthTokensEveryTimeTheConnectionComesUp() {
 
         pusher.subscribePrivate(PRIVATE_CHANNEL_NAME);
-        verify(mockAuthorizer, never()).authorize(anyString(), anyString());
+        verify(mockChannelAuthorizer, never()).authorize(anyString(), anyString());
 
         establishConnection();
-        verify(mockAuthorizer).authorize(eq(PRIVATE_CHANNEL_NAME), anyString());
+        verify(mockChannelAuthorizer).authorize(eq(PRIVATE_CHANNEL_NAME), anyString());
         testWebsocket.assertLatestMessageWas(OUTGOING_SUBSCRIBE_PRIVATE_MESSAGE);
         testWebsocket.assertNumberOfMessagesSentIs(1);
 
@@ -156,7 +156,7 @@ public class EndToEndTest {
         testWebsocket
                 .onMessage("{\"event\":\"pusher:connection_established\",\"data\":\"{\\\"socket_id\\\":\\\"23048.689386\\\"}\"}");
 
-        verify(mockAuthorizer, times(2)).authorize(eq(PRIVATE_CHANNEL_NAME), anyString());
+        verify(mockChannelAuthorizer, times(2)).authorize(eq(PRIVATE_CHANNEL_NAME), anyString());
         testWebsocket.assertLatestMessageWas(OUTGOING_SUBSCRIBE_PRIVATE_MESSAGE);
         testWebsocket.assertNumberOfMessagesSentIs(2);
     }

--- a/src/test/java/com/pusher/client/PusherOptionsTest.java
+++ b/src/test/java/com/pusher/client/PusherOptionsTest.java
@@ -21,6 +21,8 @@ public class PusherOptionsTest {
 
     private PusherOptions pusherOptions;
     private @Mock Authorizer mockAuthorizer;
+    private @Mock ChannelAuthorizer mockChannelAuthorizer;
+    private @Mock UserAuthenticator mockUserAuthenticator;
 
     @Before
     public void setUp() {
@@ -46,6 +48,29 @@ public class PusherOptionsTest {
     public void testAuthorizerCanBeSet() {
         pusherOptions.setAuthorizer(mockAuthorizer);
         assertSame(mockAuthorizer, pusherOptions.getAuthorizer());
+        assertSame(mockAuthorizer, pusherOptions.getChannelAuthorizer());
+    }
+
+    @Test
+    public void testChannelAuthorizerIsInitiallyNull() {
+        assertNull(pusherOptions.getChannelAuthorizer());
+    }
+
+    @Test
+    public void testChannelAuthorizerCanBeSet() {
+        pusherOptions.setChannelAuthorizer(mockChannelAuthorizer);
+        assertSame(mockChannelAuthorizer, pusherOptions.getChannelAuthorizer());
+    }
+
+    @Test
+    public void testUserAuthenticatorIsInitiallyNull() {
+        assertNull(pusherOptions.getUserAuthenticator());
+    }
+
+    @Test
+    public void testUserAuthenticatorBeSet() {
+        pusherOptions.setUserAuthenticator(mockUserAuthenticator);
+        assertSame(mockUserAuthenticator, pusherOptions.getUserAuthenticator());
     }
 
     @Test
@@ -63,6 +88,16 @@ public class PusherOptionsTest {
     @Test
     public void testSetAuthorizerReturnsSelf() {
         assertSame(pusherOptions, pusherOptions.setAuthorizer(mockAuthorizer));
+    }
+
+    @Test
+    public void testSetChannelAuthorizerReturnsSelf() {
+        assertSame(pusherOptions, pusherOptions.setChannelAuthorizer(mockChannelAuthorizer));
+    }
+
+    @Test
+    public void testSetUserAuthenticatorReturnsSelf() {
+        assertSame(pusherOptions, pusherOptions.setUserAuthenticator(mockUserAuthenticator));
     }
 
     @Test

--- a/src/test/java/com/pusher/client/PusherTest.java
+++ b/src/test/java/com/pusher/client/PusherTest.java
@@ -22,7 +22,7 @@ import com.pusher.client.connection.ConnectionEventListener;
 import com.pusher.client.connection.ConnectionState;
 import com.pusher.client.connection.impl.InternalConnection;
 import com.pusher.client.util.Factory;
-import com.pusher.client.util.HttpAuthorizer;
+import com.pusher.client.util.HttpChannelAuthorizer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class PusherTest {
@@ -34,7 +34,7 @@ public class PusherTest {
 
     private Pusher pusher;
     private PusherOptions options;
-    private Authorizer authorizer;
+    private ChannelAuthorizer channelAuthorizer;
     private @Mock InternalConnection mockConnection;
     private @Mock ChannelManager mockChannelManager;
     private @Mock ConnectionEventListener mockConnectionEventListener;
@@ -48,15 +48,15 @@ public class PusherTest {
 
     @Before
     public void setUp() {
-        authorizer = new HttpAuthorizer("http://www.example.com");
-        options = new PusherOptions().setAuthorizer(authorizer);
+        channelAuthorizer = new HttpChannelAuthorizer("http://www.example.com");
+        options = new PusherOptions().setChannelAuthorizer(channelAuthorizer);
 
         when(factory.getConnection(eq(API_KEY), any(PusherOptions.class))).thenReturn(mockConnection);
         when(factory.getChannelManager()).thenReturn(mockChannelManager);
         when(factory.newPublicChannel(PUBLIC_CHANNEL_NAME)).thenReturn(mockPublicChannel);
-        when(factory.newPrivateChannel(mockConnection, PRIVATE_CHANNEL_NAME, authorizer))
+        when(factory.newPrivateChannel(mockConnection, PRIVATE_CHANNEL_NAME, channelAuthorizer))
                 .thenReturn(mockPrivateChannel);
-        when(factory.newPresenceChannel(mockConnection, PRESENCE_CHANNEL_NAME, authorizer)).thenReturn(
+        when(factory.newPresenceChannel(mockConnection, PRESENCE_CHANNEL_NAME, channelAuthorizer)).thenReturn(
                 mockPresenceChannel);
         doAnswer(new Answer() {
             @Override
@@ -226,9 +226,9 @@ public class PusherTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testSubscribePresenceIfPusherOptionsHaveBeenPassedButNoAuthorizerHasBeenSetThrowsException() {
+    public void testSubscribePresenceIfPusherOptionsHaveBeenPassedButNoChannelAuthorizerHasBeenSetThrowsException() {
         when(mockConnection.getState()).thenReturn(ConnectionState.CONNECTED);
-        options.setAuthorizer(null);
+        options.setChannelAuthorizer(null);
         pusher = new Pusher(API_KEY, options);
 
         pusher.subscribePresence(PRESENCE_CHANNEL_NAME, mockPresenceChannelEventListener);
@@ -277,9 +277,9 @@ public class PusherTest {
     }
 
     @Test(expected = IllegalStateException.class)
-    public void testSubscribePrivateIfPusherOptionsHaveBeenPassedButNoAuthorizerHasBeenSetThrowsException() {
+    public void testSubscribePrivateIfPusherOptionsHaveBeenPassedButNoChannelAuthorizerHasBeenSetThrowsException() {
         when(mockConnection.getState()).thenReturn(ConnectionState.CONNECTED);
-        options.setAuthorizer(null);
+        options.setChannelAuthorizer(null);
         pusher = new Pusher(API_KEY, options);
 
         pusher.subscribePrivate(PRIVATE_CHANNEL_NAME, mockPrivateChannelEventListener);

--- a/src/test/java/com/pusher/client/channel/impl/PresenceChannelImplTest.java
+++ b/src/test/java/com/pusher/client/channel/impl/PresenceChannelImplTest.java
@@ -47,7 +47,7 @@ public class PresenceChannelImplTest extends PrivateChannelImplTest {
     public void setUp() {
         super.setUp();
         channel.setEventListener(mockEventListener);
-        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("{" + AUTH_RESPONSE + "," + AUTH_RESPONSE_CHANNEL_DATA + "}");
+        when(mockChannelAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("{" + AUTH_RESPONSE + "," + AUTH_RESPONSE_CHANNEL_DATA + "}");
     }
 
     @Test
@@ -63,7 +63,7 @@ public class PresenceChannelImplTest extends PrivateChannelImplTest {
 
     @Test
     public void testReturnsCorrectSubscribeMessageWhenNumericId() {
-        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn(
+        when(mockChannelAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn(
                 "{" + AUTH_RESPONSE_NUMERIC_ID + "," + AUTH_RESPONSE_NUMERIC_ID_CHANNEL_DATA + "}");
 
         final String message = channel.toSubscribeMessage();
@@ -269,7 +269,7 @@ public class PresenceChannelImplTest extends PrivateChannelImplTest {
 
     @Override
     protected ChannelImpl newInstance(final String channelName) {
-        return new PresenceChannelImpl(mockConnection, channelName, mockAuthorizer, factory);
+        return new PresenceChannelImpl(mockConnection, channelName, mockChannelAuthorizer, factory);
     }
 
     @Override

--- a/src/test/java/com/pusher/client/channel/impl/PrivateChannelImplTest.java
+++ b/src/test/java/com/pusher/client/channel/impl/PrivateChannelImplTest.java
@@ -10,7 +10,7 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.pusher.client.AuthorizationFailureException;
-import com.pusher.client.Authorizer;
+import com.pusher.client.ChannelAuthorizer;
 import com.pusher.client.channel.ChannelEventListener;
 import com.pusher.client.channel.ChannelState;
 import com.pusher.client.channel.PrivateChannelEventListener;
@@ -26,13 +26,13 @@ public class PrivateChannelImplTest extends ChannelImplTest {
     @Mock
     protected InternalConnection mockConnection;
     @Mock
-    protected Authorizer mockAuthorizer;
+    protected ChannelAuthorizer mockChannelAuthorizer;
 
     @Override
     @Before
     public void setUp() {
         super.setUp();
-        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("{" + AUTH_RESPONSE + "}");
+        when(mockChannelAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("{" + AUTH_RESPONSE + "}");
     }
 
     @Test
@@ -86,7 +86,7 @@ public class PrivateChannelImplTest extends ChannelImplTest {
 
     @Test
     public void testReturnsCorrectSubscribeMessageWithChannelData() {
-        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn(
+        when(mockChannelAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn(
                 "{" + AUTH_RESPONSE + "," + AUTH_RESPONSE_CHANNEL_DATA + "}");
 
         assertEquals("{\"event\":\"pusher:subscribe\",\"data\":{"
@@ -98,26 +98,26 @@ public class PrivateChannelImplTest extends ChannelImplTest {
 
     @Test(expected = AuthorizationFailureException.class)
     public void testThrowsAuthorizationFailureExceptionIfAuthorizerThrowsException() {
-        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenThrow(
+        when(mockChannelAuthorizer.authorize(eq(getChannelName()), anyString())).thenThrow(
                 new AuthorizationFailureException("Unable to contact auth server"));
         channel.toSubscribeMessage();
     }
 
     @Test(expected = AuthorizationFailureException.class)
     public void testThrowsAuthorizationFailureExceptionIfAuthorizerReturnsBasicString() {
-        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("I'm a string");
+        when(mockChannelAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("I'm a string");
         channel.toSubscribeMessage();
     }
 
     @Test(expected = AuthorizationFailureException.class)
     public void testThrowsAuthorizationFailureExceptionIfAuthorizerReturnsInvalidJSON() {
-        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("{\"auth\":\"");
+        when(mockChannelAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("{\"auth\":\"");
         channel.toSubscribeMessage();
     }
 
     @Test(expected = AuthorizationFailureException.class)
     public void testThrowsAuthorizationFailureExceptionIfAuthorizerReturnsJSONWithoutAnAuthToken() {
-        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("{\"fish\":\"chips\"");
+        when(mockChannelAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn("{\"fish\":\"chips\"");
         channel.toSubscribeMessage();
     }
 
@@ -210,7 +210,7 @@ public class PrivateChannelImplTest extends ChannelImplTest {
 
     @Override
     protected ChannelImpl newInstance(final String channelName) {
-        return new PrivateChannelImpl(mockConnection, channelName, mockAuthorizer, factory);
+        return new PrivateChannelImpl(mockConnection, channelName, mockChannelAuthorizer, factory);
     }
 
     @Override

--- a/src/test/java/com/pusher/client/channel/impl/PrivateEncryptedChannelClearsKeyTest.java
+++ b/src/test/java/com/pusher/client/channel/impl/PrivateEncryptedChannelClearsKeyTest.java
@@ -2,7 +2,7 @@ package com.pusher.client.channel.impl;
 
 import static org.mockito.Mockito.*;
 
-import com.pusher.client.Authorizer;
+import com.pusher.client.ChannelAuthorizer;
 import com.pusher.client.channel.ChannelState;
 import com.pusher.client.connection.ConnectionEventListener;
 import com.pusher.client.connection.ConnectionState;
@@ -27,7 +27,7 @@ public class PrivateEncryptedChannelClearsKeyTest {
     @Mock
     InternalConnection mockInternalConnection;
     @Mock
-    Authorizer mockAuthorizer;
+    ChannelAuthorizer mockChannelAuthorizer;
     @Mock
     Factory mockFactory;
 
@@ -40,11 +40,11 @@ public class PrivateEncryptedChannelClearsKeyTest {
 
     @Before
     public void setUp() {
-        when(mockAuthorizer.authorize(eq(CHANNEL_NAME), anyString())).thenReturn(AUTH_RESPONSE);
+        when(mockChannelAuthorizer.authorize(eq(CHANNEL_NAME), anyString())).thenReturn(AUTH_RESPONSE);
         when(mockSecretBoxOpenerFactory.create(any())).thenReturn(mockSecretBoxOpener);
 
         subject = new PrivateEncryptedChannelImpl(mockInternalConnection, CHANNEL_NAME,
-                mockAuthorizer, mockFactory, mockSecretBoxOpenerFactory);
+                mockChannelAuthorizer, mockFactory, mockSecretBoxOpenerFactory);
     }
 
     @Test

--- a/src/test/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImplTest.java
+++ b/src/test/java/com/pusher/client/channel/impl/PrivateEncryptedChannelImplTest.java
@@ -1,7 +1,7 @@
 package com.pusher.client.channel.impl;
 
 import com.pusher.client.AuthorizationFailureException;
-import com.pusher.client.Authorizer;
+import com.pusher.client.ChannelAuthorizer;
 import com.pusher.client.channel.ChannelEventListener;
 import com.pusher.client.channel.PrivateEncryptedChannelEventListener;
 import com.pusher.client.connection.impl.InternalConnection;
@@ -39,7 +39,7 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
     @Mock
     InternalConnection mockInternalConnection;
     @Mock
-    Authorizer mockAuthorizer;
+    ChannelAuthorizer mockChannelAuthorizer;
     @Mock
     SecretBoxOpenerFactory mockSecretBoxOpenerFactory;
 
@@ -47,17 +47,17 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
     @Before
     public void setUp() {
         super.setUp();
-        when(mockAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn(AUTH_RESPONSE);
+        when(mockChannelAuthorizer.authorize(eq(getChannelName()), anyString())).thenReturn(AUTH_RESPONSE);
     }
 
     protected PrivateEncryptedChannelImpl newInstance() {
         return new PrivateEncryptedChannelImpl(mockInternalConnection, getChannelName(),
-                mockAuthorizer, factory, mockSecretBoxOpenerFactory);
+                mockChannelAuthorizer, factory, mockSecretBoxOpenerFactory);
     }
 
     @Override
     protected ChannelImpl newInstance(final String channelName) {
-        return new PrivateEncryptedChannelImpl(mockInternalConnection, channelName, mockAuthorizer,
+        return new PrivateEncryptedChannelImpl(mockInternalConnection, channelName, mockChannelAuthorizer,
                 factory, mockSecretBoxOpenerFactory);
     }
 
@@ -115,8 +115,8 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
      */
 
     @Test
-    public void authenticationSucceedsGivenValidAuthorizer() {
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+    public void authenticationSucceedsGivenValidChannelAuthorizer() {
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE);
 
         PrivateEncryptedChannelImpl channel = newInstance();
@@ -130,7 +130,7 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
 
     @Test(expected = AuthorizationFailureException.class)
     public void authenticationThrowsExceptionIfNoAuthKey() {
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE_MISSING_AUTH);
 
         PrivateEncryptedChannelImpl channel = newInstance();
@@ -140,7 +140,7 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
 
     @Test(expected = AuthorizationFailureException.class)
     public void authenticationThrowsExceptionIfNoSharedSecret() {
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE_MISSING_SHARED_SECRET);
 
         PrivateEncryptedChannelImpl channel = newInstance();
@@ -150,7 +150,7 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
 
     @Test(expected = AuthorizationFailureException.class)
     public void authenticationThrowsExceptionIfMalformedJson() {
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE_INVALID_JSON);
 
         PrivateEncryptedChannelImpl channel = newInstance();
@@ -166,11 +166,11 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
         PrivateEncryptedChannelImpl channel = new PrivateEncryptedChannelImpl(
                 mockInternalConnection,
                 getChannelName(),
-                mockAuthorizer,
+                mockChannelAuthorizer,
                 factory,
                 mockSecretBoxOpenerFactory);
 
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE);
         when(mockSecretBoxOpenerFactory.create(any()))
                 .thenReturn(new SecretBoxOpener(Base64.decode(SHARED_SECRET)));
@@ -195,11 +195,11 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
         PrivateEncryptedChannelImpl channel = new PrivateEncryptedChannelImpl(
                 mockInternalConnection,
                 getChannelName(),
-                mockAuthorizer,
+                mockChannelAuthorizer,
                 factory,
                 mockSecretBoxOpenerFactory);
 
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE);
         when(mockSecretBoxOpenerFactory.create(any()))
                 .thenReturn(new SecretBoxOpener(Base64.decode(SHARED_SECRET)));
@@ -225,11 +225,11 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
         PrivateEncryptedChannelImpl channel = new PrivateEncryptedChannelImpl(
                 mockInternalConnection,
                 getChannelName(),
-                mockAuthorizer,
+                mockChannelAuthorizer,
                 factory,
                 mockSecretBoxOpenerFactory);
 
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE);
         when(mockSecretBoxOpenerFactory.create(any()))
                 .thenReturn(new SecretBoxOpener(Base64.decode(SHARED_SECRET)));
@@ -260,11 +260,11 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
         PrivateEncryptedChannelImpl channel = new PrivateEncryptedChannelImpl(
                 mockInternalConnection,
                 getChannelName(),
-                mockAuthorizer,
+                mockChannelAuthorizer,
                 factory,
                 mockSecretBoxOpenerFactory);
 
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE_INCORRECT_SHARED_SECRET)
                 .thenReturn(AUTH_RESPONSE_INCORRECT_SHARED_SECRET);
         when(mockSecretBoxOpenerFactory.create(any()))
@@ -288,11 +288,11 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
         PrivateEncryptedChannelImpl channel = new PrivateEncryptedChannelImpl(
                 mockInternalConnection,
                 getChannelName(),
-                mockAuthorizer,
+                mockChannelAuthorizer,
                 factory,
                 mockSecretBoxOpenerFactory);
 
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE_INCORRECT_SHARED_SECRET)
                 .thenReturn(AUTH_RESPONSE);
         when(mockSecretBoxOpenerFactory.create(any()))
@@ -319,11 +319,11 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
         PrivateEncryptedChannelImpl channel = new PrivateEncryptedChannelImpl(
                 mockInternalConnection,
                 getChannelName(),
-                mockAuthorizer,
+                mockChannelAuthorizer,
                 factory,
                 mockSecretBoxOpenerFactory);
 
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE_INCORRECT_SHARED_SECRET)
                 .thenReturn(AUTH_RESPONSE_INCORRECT_SHARED_SECRET)
                 .thenReturn(AUTH_RESPONSE);
@@ -360,11 +360,11 @@ public class PrivateEncryptedChannelImplTest extends ChannelImplTest {
         PrivateEncryptedChannelImpl channel = new PrivateEncryptedChannelImpl(
                 mockInternalConnection,
                 getChannelName(),
-                mockAuthorizer,
+                mockChannelAuthorizer,
                 factory,
                 mockSecretBoxOpenerFactory);
 
-        when(mockAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
+        when(mockChannelAuthorizer.authorize(Matchers.anyString(), Matchers.anyString()))
                 .thenReturn(AUTH_RESPONSE_INCORRECT_SHARED_SECRET)
                 .thenReturn(AUTH_RESPONSE_INCORRECT_SHARED_SECRET)
                 .thenReturn(AUTH_RESPONSE_INCORRECT_SHARED_SECRET);

--- a/src/test/java/com/pusher/client/util/HttpChannelAuthorizerTest.java
+++ b/src/test/java/com/pusher/client/util/HttpChannelAuthorizerTest.java
@@ -7,28 +7,28 @@ import com.pusher.client.AuthorizationFailureException;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-public class HttpAuthorizerTest {
+public class HttpChannelAuthorizerTest {
 
     @Test(expected = IllegalArgumentException.class)
     public void testConstructWithMalformedURLThrowsRuntimeException() {
-        new HttpAuthorizer("bad url");
+        new HttpChannelAuthorizer("bad url");
     }
 
     @Test
     public void testHTTPURLIsIdentifiedAsSSL() {
-        final HttpAuthorizer auth = new HttpAuthorizer("http://example.com/auth");
+        final HttpChannelAuthorizer auth = new HttpChannelAuthorizer("http://example.com/auth");
         assertFalse(auth.isSSL());
     }
 
     @Test
     public void testHTTPSURLIsIdentifiedAsSSL() {
-        final HttpAuthorizer auth = new HttpAuthorizer("https://example.com/auth");
+        final HttpChannelAuthorizer auth = new HttpChannelAuthorizer("https://example.com/auth");
         assertTrue(auth.isSSL());
     }
 
     @Test(expected = AuthorizationFailureException.class)
     public void testNon200ResponseThrowsAuthorizationFailureException() {
-        final HttpAuthorizer auth = new HttpAuthorizer("https://127.0.0.1/no-way-this-is-a-valid-url");
+        final HttpChannelAuthorizer auth = new HttpChannelAuthorizer("https://127.0.0.1/no-way-this-is-a-valid-url");
         auth.authorize("private-fish", "some socket id");
     }
 }

--- a/src/test/java/com/pusher/client/util/HttpUserAuthenticatorTest.java
+++ b/src/test/java/com/pusher/client/util/HttpUserAuthenticatorTest.java
@@ -1,0 +1,34 @@
+package com.pusher.client.util;
+
+import org.junit.Test;
+
+import com.pusher.client.AuthenticationFailureException;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class HttpUserAuthenticatorTest {
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testConstructWithMalformedURLThrowsRuntimeException() {
+        new HttpUserAuthenticator("bad url");
+    }
+
+    @Test
+    public void testHTTPURLIsIdentifiedAsSSL() {
+        final HttpUserAuthenticator auth = new HttpUserAuthenticator("http://example.com/auth");
+        assertFalse(auth.isSSL());
+    }
+
+    @Test
+    public void testHTTPSURLIsIdentifiedAsSSL() {
+        final HttpUserAuthenticator auth = new HttpUserAuthenticator("https://example.com/auth");
+        assertTrue(auth.isSSL());
+    }
+
+    @Test(expected = AuthenticationFailureException.class)
+    public void testNon200ResponseThrowsAuthenticationFailtureException() {
+        final HttpUserAuthenticator auth = new HttpUserAuthenticator("https://127.0.0.1/no-way-this-is-a-valid-url");
+        auth.authenticate("some socket id");
+    }
+}


### PR DESCRIPTION
### Description of the pull request

First PR to start introducing user signin and server to user messages. This PR doesn't provide any feature yet.

#### Why is the change necessary?

This PR introduces the `UserAuthenticator`, to be used to perform authentication when signing in. It also renames the `Authorizer` class to `ChannelAuthorizer` while keeping the deprecated names for backwards compatibility.

----

CC @pusher/mobile 
