### PR TITLE
Add support for user signin and server to user messages

### DIFF
--- a/src/main/java/com/pusher/client/channel/impl/BaseChannel.java
+++ b/src/main/java/com/pusher/client/channel/impl/BaseChannel.java
@@ -182,11 +182,6 @@ public abstract class BaseChannel implements InternalChannel {
             throw new IllegalArgumentException("Cannot bind or unbind channel " + getName()
                     + " with an internal event name such as " + eventName);
         }
-
-        if (state == ChannelState.UNSUBSCRIBED) {
-            throw new IllegalStateException(
-                    "Cannot bind or unbind to events on a channel that has been unsubscribed. Call Pusher.subscribe() to resubscribe to this channel");
-        }
     }
 
     protected Set<SubscriptionEventListener> getInterestedListeners(String event) {

--- a/src/main/java/com/pusher/client/channel/impl/BaseChannel.java
+++ b/src/main/java/com/pusher/client/channel/impl/BaseChannel.java
@@ -1,0 +1,213 @@
+package com.pusher.client.channel.impl;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.gson.Gson;
+
+import com.google.gson.GsonBuilder;
+import com.pusher.client.channel.*;
+import com.pusher.client.channel.impl.message.SubscribeMessage;
+import com.pusher.client.channel.impl.message.UnsubscribeMessage;
+import com.pusher.client.util.Factory;
+
+public abstract class BaseChannel implements InternalChannel {
+    protected final Gson GSON;
+    private static final String INTERNAL_EVENT_PREFIX = "pusher_internal:";
+    protected static final String SUBSCRIPTION_SUCCESS_EVENT = "pusher_internal:subscription_succeeded";
+    private Set<SubscriptionEventListener> globalListeners = new HashSet<SubscriptionEventListener>();
+    private final Map<String, Set<SubscriptionEventListener>> eventNameToListenerMap = new HashMap<String, Set<SubscriptionEventListener>>();
+    protected volatile ChannelState state = ChannelState.INITIAL;
+    private ChannelEventListener eventListener;
+    private final Factory factory;
+    private final Object lock = new Object();
+
+    public BaseChannel(final Factory factory) {
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(PusherEvent.class, new PusherEventDeserializer());
+        GSON = gsonBuilder.create();
+        this.factory = factory;
+    }
+
+    /* Channel implementation */
+
+    @Override
+    abstract public String getName();
+
+    @Override
+    public void bind(final String eventName, final SubscriptionEventListener listener) {
+        validateArguments(eventName, listener);
+
+        synchronized (lock) {
+            Set<SubscriptionEventListener> listeners = eventNameToListenerMap.get(eventName);
+            if (listeners == null) {
+                listeners = new HashSet<SubscriptionEventListener>();
+                eventNameToListenerMap.put(eventName, listeners);
+            }
+            listeners.add(listener);
+        }
+    }
+
+    @Override
+    public void bindGlobal(SubscriptionEventListener listener) {
+        validateArguments("", listener);
+
+        synchronized(lock) {
+            globalListeners.add(listener);
+        }
+    }
+
+    @Override
+    public void unbind(String eventName, SubscriptionEventListener listener) {
+        validateArguments(eventName, listener);
+
+        synchronized (lock) {
+            final Set<SubscriptionEventListener> listeners = eventNameToListenerMap.get(eventName);
+            if (listeners != null) {
+                listeners.remove(listener);
+                if (listeners.isEmpty()) {
+                    eventNameToListenerMap.remove(eventName);
+                }
+            }
+        }
+    }
+
+    @Override
+    public void unbindGlobal(SubscriptionEventListener listener) {
+        validateArguments("", listener);
+
+        synchronized(lock) {
+            if (globalListeners != null) {
+                globalListeners.remove(listener);
+            }
+        }
+    }
+
+    @Override
+    public boolean isSubscribed() {
+        return state == ChannelState.SUBSCRIBED;
+    }
+
+    /* InternalChannel implementation */
+
+    @Override
+    public String toSubscribeMessage() {
+        return GSON.toJson(new SubscribeMessage(getName()));
+    }
+
+    @Override
+    public String toUnsubscribeMessage() {
+        return GSON.toJson(new UnsubscribeMessage(getName()));
+    }
+
+    @Override
+    public PusherEvent prepareEvent(String event, String message) {
+        return GSON.fromJson(message, PusherEvent.class);
+    }
+
+    @Override
+    public void onMessage(String event, String message) {
+        if (event.equals(SUBSCRIPTION_SUCCESS_EVENT)) {
+            updateState(ChannelState.SUBSCRIBED);
+        } else {
+            final Set<SubscriptionEventListener> listeners = getInterestedListeners(event);
+            if (listeners != null) {
+                final PusherEvent pusherEvent = prepareEvent(event, message);
+                if (pusherEvent != null) {
+                    for (final SubscriptionEventListener listener : listeners) {
+                        factory.queueOnEventThread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    listener.onEvent(pusherEvent);
+                                }
+                            });
+                    }
+                }
+            }
+        }
+    }
+
+    @Override
+    public void updateState(ChannelState state) {
+        this.state = state;
+
+        if (state == ChannelState.SUBSCRIBED && eventListener != null) {
+            factory.queueOnEventThread(new Runnable() {
+                    @Override
+                    public void run() {
+                        eventListener.onSubscriptionSucceeded(getName());
+                    }
+                });
+        }
+    }
+
+    @Override
+    public void setEventListener(final ChannelEventListener listener) {
+        eventListener = listener;
+    }
+
+    @Override
+    public ChannelEventListener getEventListener() {
+        return eventListener;
+    }
+
+    /* Comparable implementation */
+
+    @Override
+    public int compareTo(final InternalChannel other) {
+        return getName().compareTo(other.getName());
+    }
+
+    /* Implementation detail */
+
+    @Override
+    public String toString() {
+        return String.format("[Channel: name=%s]", getName());
+    }
+
+     private void validateArguments(final String eventName, final SubscriptionEventListener listener) {
+
+        if (eventName == null) {
+            throw new IllegalArgumentException("Cannot bind or unbind to channel " + getName() + " with a null event name");
+        }
+
+        if (listener == null) {
+            throw new IllegalArgumentException("Cannot bind or unbind to channel " + getName() + " with a null listener");
+        }
+
+        if (eventName.startsWith(INTERNAL_EVENT_PREFIX)) {
+            throw new IllegalArgumentException("Cannot bind or unbind channel " + getName()
+                    + " with an internal event name such as " + eventName);
+        }
+
+        if (state == ChannelState.UNSUBSCRIBED) {
+            throw new IllegalStateException(
+                    "Cannot bind or unbind to events on a channel that has been unsubscribed. Call Pusher.subscribe() to resubscribe to this channel");
+        }
+    }
+
+    protected Set<SubscriptionEventListener> getInterestedListeners(String event) {
+        synchronized (lock) {
+            Set<SubscriptionEventListener> listeners = new HashSet<SubscriptionEventListener>();
+
+            final Set<SubscriptionEventListener> sharedListeners =
+                    eventNameToListenerMap.get(event);
+
+            if (sharedListeners != null ) {
+                listeners.addAll(sharedListeners);
+            }
+            if (!globalListeners.isEmpty()) {
+                listeners.addAll(globalListeners);
+            }
+
+            if (listeners.isEmpty()){
+                return null;
+            }
+
+            return listeners;
+        }
+    }
+}

--- a/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/ChannelImpl.java
@@ -1,35 +1,12 @@
 package com.pusher.client.channel.impl;
 
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.Map;
-import java.util.Set;
-
-import com.google.gson.Gson;
-
-import com.google.gson.GsonBuilder;
-import com.pusher.client.channel.*;
-import com.pusher.client.channel.impl.message.SubscribeMessage;
-import com.pusher.client.channel.impl.message.UnsubscribeMessage;
 import com.pusher.client.util.Factory;
 
-public class ChannelImpl implements InternalChannel {
-    protected final Gson GSON;
-    private static final String INTERNAL_EVENT_PREFIX = "pusher_internal:";
-    protected static final String SUBSCRIPTION_SUCCESS_EVENT = "pusher_internal:subscription_succeeded";
+public class ChannelImpl extends BaseChannel {
     protected final String name;
-    private Set<SubscriptionEventListener> globalListeners = new HashSet<SubscriptionEventListener>();
-    private final Map<String, Set<SubscriptionEventListener>> eventNameToListenerMap = new HashMap<String, Set<SubscriptionEventListener>>();
-    protected volatile ChannelState state = ChannelState.INITIAL;
-    private ChannelEventListener eventListener;
-    private final Factory factory;
-    private final Object lock = new Object();
 
     public ChannelImpl(final String channelName, final Factory factory) {
-        GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.registerTypeAdapter(PusherEvent.class, new PusherEventDeserializer());
-        GSON = gsonBuilder.create();
+        super(factory);
         if (channelName == null) {
             throw new IllegalArgumentException("Cannot subscribe to a channel with a null name");
         }
@@ -44,198 +21,18 @@ public class ChannelImpl implements InternalChannel {
         }
 
         name = channelName;
-        this.factory = factory;
     }
-
-    /* Channel implementation */
 
     @Override
     public String getName() {
         return name;
     }
-
-    @Override
-    public void bind(final String eventName, final SubscriptionEventListener listener) {
-
-        validateArguments(eventName, listener);
-
-        synchronized (lock) {
-            Set<SubscriptionEventListener> listeners = eventNameToListenerMap.get(eventName);
-            if (listeners == null) {
-                listeners = new HashSet<SubscriptionEventListener>();
-                eventNameToListenerMap.put(eventName, listeners);
-            }
-            listeners.add(listener);
-        }
-    }
-
-    @Override
-    public void bindGlobal(SubscriptionEventListener listener) {
-        validateArguments("", listener);
-
-        synchronized(lock) {
-            globalListeners.add(listener);
-        }
-    }
-
-    @Override
-    public void unbind(final String eventName, final SubscriptionEventListener listener) {
-
-        validateArguments(eventName, listener);
-
-        synchronized (lock) {
-            final Set<SubscriptionEventListener> listeners = eventNameToListenerMap.get(eventName);
-            if (listeners != null) {
-                listeners.remove(listener);
-                if (listeners.isEmpty()) {
-                    eventNameToListenerMap.remove(eventName);
-                }
-            }
-        }
-    }
-
-    @Override
-    public void unbindGlobal(SubscriptionEventListener listener) {
-        validateArguments("", listener);
-
-        synchronized(lock) {
-            if (globalListeners != null) {
-                globalListeners.remove(listener);
-            }
-        }
-    }
-
-    @Override
-    public boolean isSubscribed() {
-        return state == ChannelState.SUBSCRIBED;
-    }
-
-    /* InternalChannel implementation */
-
-    @Override
-    public PusherEvent prepareEvent(String event, String message) {
-        return GSON.fromJson(message, PusherEvent.class);
-    }
-
-    @Override
-    public void onMessage(final String event, final String message) {
-
-        if (event.equals(SUBSCRIPTION_SUCCESS_EVENT)) {
-            updateState(ChannelState.SUBSCRIBED);
-        } else {
-            final Set<SubscriptionEventListener> listeners = getInterestedListeners(event);
-            if (listeners != null) {
-                final PusherEvent pusherEvent = prepareEvent(event, message);
-                if (pusherEvent != null) {
-                    for (final SubscriptionEventListener listener : listeners) {
-                        factory.queueOnEventThread(new Runnable() {
-                            @Override
-                            public void run() {
-                                listener.onEvent(pusherEvent);
-                            }
-                        });
-                    }
-                }
-            }
-        }
-    }
-
-
-    @Override
-    public String toSubscribeMessage() {
-        return GSON.toJson(new SubscribeMessage(name));
-    }
-
-    @Override
-    public String toUnsubscribeMessage() {
-        return GSON.toJson(
-                new UnsubscribeMessage(name));
-    }
-
-    @Override
-    public void updateState(final ChannelState state) {
-
-        this.state = state;
-
-        if (state == ChannelState.SUBSCRIBED && eventListener != null) {
-            factory.queueOnEventThread(new Runnable() {
-                @Override
-                public void run() {
-                    eventListener.onSubscriptionSucceeded(ChannelImpl.this.getName());
-                }
-            });
-        }
-    }
-
-    /* Comparable implementation */
-
-    @Override
-    public void setEventListener(final ChannelEventListener listener) {
-        eventListener = listener;
-    }
-
-    @Override
-    public ChannelEventListener getEventListener() {
-        return eventListener;
-    }
-
-    @Override
-    public int compareTo(final InternalChannel other) {
-        return getName().compareTo(other.getName());
-    }
-
-    /* implementation detail */
-
     @Override
     public String toString() {
         return String.format("[Public Channel: name=%s]", name);
     }
 
-
     protected String[] getDisallowedNameExpressions() {
         return new String[] { "^private-.*", "^presence-.*" };
-    }
-
-    private void validateArguments(final String eventName, final SubscriptionEventListener listener) {
-
-        if (eventName == null) {
-            throw new IllegalArgumentException("Cannot bind or unbind to channel " + name + " with a null event name");
-        }
-
-        if (listener == null) {
-            throw new IllegalArgumentException("Cannot bind or unbind to channel " + name + " with a null listener");
-        }
-
-        if (eventName.startsWith(INTERNAL_EVENT_PREFIX)) {
-            throw new IllegalArgumentException("Cannot bind or unbind channel " + name
-                    + " with an internal event name such as " + eventName);
-        }
-
-        if (state == ChannelState.UNSUBSCRIBED) {
-            throw new IllegalStateException(
-                    "Cannot bind or unbind to events on a channel that has been unsubscribed. Call Pusher.subscribe() to resubscribe to this channel");
-        }
-    }
-
-    protected Set<SubscriptionEventListener> getInterestedListeners(String event) {
-        synchronized (lock) {
-            Set<SubscriptionEventListener> listeners = new HashSet<SubscriptionEventListener>();
-
-            final Set<SubscriptionEventListener> sharedListeners =
-                    eventNameToListenerMap.get(event);
-
-            if (sharedListeners != null ) {
-                listeners.addAll(sharedListeners);
-            }
-            if (!globalListeners.isEmpty()) {
-                listeners.addAll(globalListeners);
-            }
-
-            if (listeners.isEmpty()){
-                return null;
-            }
-
-            return listeners;
-        }
     }
 }

--- a/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
+++ b/src/main/java/com/pusher/client/channel/impl/PrivateChannelImpl.java
@@ -82,7 +82,7 @@ public class PrivateChannelImpl extends ChannelImpl implements PrivateChannel {
                 return authResponse.getAuth();
             }
         }  catch (JsonSyntaxException e) {
-            throw new AuthorizationFailureException("Unable to parse response from Authorizer");
+            throw new AuthorizationFailureException("Unable to parse response from ChannelAuthorizer");
         }
     }
 

--- a/src/main/java/com/pusher/client/channel/impl/message/SubscribeMessage.java
+++ b/src/main/java/com/pusher/client/channel/impl/message/SubscribeMessage.java
@@ -2,7 +2,6 @@ package com.pusher.client.channel.impl.message;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
 
 public class SubscribeMessage {
     private String event = "pusher:subscribe";

--- a/src/main/java/com/pusher/client/user/User.java
+++ b/src/main/java/com/pusher/client/user/User.java
@@ -1,0 +1,81 @@
+package com.pusher.client.user;
+
+import com.pusher.client.channel.SubscriptionEventListener;
+
+/**
+ * An object that represents a user on a Pusher connection. An implementation of this
+ * interface is returned when you call {@link com.pusher.client.Pusher#user()}.
+ */
+public interface User {
+    /**
+     *
+     * @return The user id of the signed in user. Null if no user is signed in;
+     */
+    String userId();
+
+    /**
+     * Binds a {@link SubscriptionEventListener} to an event. The
+     * {@link SubscriptionEventListener} will be notified whenever the specified
+     * event is received for this user.
+     *
+     * @param eventName
+     *            The name of the event to listen to.
+     * @param listener
+     *            A listener to receive notifications when the event is
+     *            received.
+     * @throws IllegalArgumentException
+     *             If either of the following are true:
+     *             <ul>
+     *             <li>The name of the event is null.</li>
+     *             <li>The {@link SubscriptionEventListener} is null.</li>
+     *             </ul>
+     */
+    void bind(String eventName, SubscriptionEventListener listener);
+
+    /**
+     * Binds a {@link SubscriptionEventListener} to all events. The
+     * {@link SubscriptionEventListener} will be notified whenever an
+     * event is received for this user.
+     *
+     * @param listener
+     *            A listener to receive notifications when the event is
+     *            received.
+     * @throws IllegalArgumentException
+     *             If the {@link SubscriptionEventListener} is null.
+     */
+    void bindGlobal(SubscriptionEventListener listener);
+
+    /**
+     * <p>
+     * Unbinds a previously bound {@link SubscriptionEventListener} from an
+     * event. The {@link SubscriptionEventListener} will no longer be notified
+     * whenever the specified event is received for this user.
+     * </p>
+     *
+     * @param eventName
+     *            The name of the event to stop listening to.
+     * @param listener
+     *            The listener to unbind from the event.
+     * @throws IllegalArgumentException
+     *             If either of the following are true:
+     *             <ul>
+     *             <li>The name of the event is null.</li>
+     *             <li>The {@link SubscriptionEventListener} is null.</li>
+     *             </ul>
+     */
+    void unbind(String eventName, SubscriptionEventListener listener);
+
+    /**
+     * <p>
+     * Unbinds a previously bound {@link SubscriptionEventListener} from global
+     * events. The {@link SubscriptionEventListener} will no longer be notified
+     * whenever the any event is received for this user.
+     * </p>
+     *
+     * @param listener
+     *            The listener to unbind from the event.
+     * @throws IllegalArgumentException
+     *             If the {@link SubscriptionEventListener} is null.
+     */
+    void unbindGlobal(SubscriptionEventListener listener);
+}

--- a/src/main/java/com/pusher/client/user/impl/InternalUser.java
+++ b/src/main/java/com/pusher/client/user/impl/InternalUser.java
@@ -117,7 +117,7 @@ public class InternalUser implements User {
         String response = userAuthenticator.authenticate(connection.getSocketId());
         try {
             AuthenticationResponse authenticationResponse = GSON.fromJson(response, AuthenticationResponse.class);
-            if (authenticationResponse.getAuth() == null && authenticationResponse.getUserData() == null) {
+            if (authenticationResponse.getAuth() == null || authenticationResponse.getUserData() == null) {
                 throw new AuthenticationFailureException("Didn't receive all the fields expected from the UserAuthenticator. Expected auth and user_data");
             }
             return authenticationResponse;

--- a/src/main/java/com/pusher/client/user/impl/InternalUser.java
+++ b/src/main/java/com/pusher/client/user/impl/InternalUser.java
@@ -1,0 +1,174 @@
+package com.pusher.client.user.impl;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonSyntaxException;
+
+import com.pusher.client.UserAuthenticator;
+import com.pusher.client.AuthenticationFailureException;
+import com.pusher.client.channel.PusherEvent;
+import com.pusher.client.channel.PusherEventDeserializer;
+import com.pusher.client.channel.SubscriptionEventListener;
+import com.pusher.client.channel.impl.ChannelManager;
+import com.pusher.client.connection.ConnectionEventListener;
+import com.pusher.client.connection.ConnectionState;
+import com.pusher.client.connection.ConnectionStateChange;
+import com.pusher.client.connection.impl.InternalConnection;
+import com.pusher.client.connection.impl.message.AuthenticationResponse;
+import com.pusher.client.connection.impl.message.SigninMessage;
+import com.pusher.client.user.User;
+import com.pusher.client.util.Factory;
+
+import java.util.Map;
+import java.util.logging.Logger;
+
+public class InternalUser implements User {
+    private static final Gson GSON;
+    private static final Logger log = Logger.getLogger(User.class.getName());
+
+    static {
+        GsonBuilder gsonBuilder = new GsonBuilder();
+        gsonBuilder.registerTypeAdapter(PusherEvent.class, new PusherEventDeserializer());
+        GSON = gsonBuilder.create();
+    }
+
+    private static class ConnectionStateChangeHandler implements ConnectionEventListener {
+        private InternalUser user;
+
+        public ConnectionStateChangeHandler(InternalUser user) {
+            this.user = user;
+        }
+
+        @Override
+        public void onConnectionStateChange(ConnectionStateChange change) {
+            switch (change.getCurrentState()) {
+            case CONNECTED:
+                user.attemptSignin();
+                break;
+            case CONNECTING:
+            case DISCONNECTED:
+                user.disconnect();
+                break;
+            default:
+                // NOOP
+            }
+        }
+
+        @Override
+        public void onError(String message, String code, Exception e) {
+            log.warning(message);
+        }
+    }
+
+    private final InternalConnection connection;
+    private final UserAuthenticator userAuthenticator;
+    private final ChannelManager channelManager;
+    private boolean signinRequested;
+    private ServerToUserChannel serverToUserChannel;
+    private String userId;
+
+    public InternalUser(InternalConnection connection, UserAuthenticator userAuthenticator, Factory factory) {
+        this.connection = connection;
+        this.userAuthenticator = userAuthenticator;
+        this.channelManager = factory.getChannelManager();
+        this.signinRequested = false;
+        this.serverToUserChannel = new ServerToUserChannel(this, factory);
+
+        connection.bind(ConnectionState.ALL, new ConnectionStateChangeHandler(this));
+    }
+
+    public void signin() throws AuthenticationFailureException {
+        if (signinRequested || userId != null) {
+            return;
+        }
+
+        signinRequested = true;
+        attemptSignin();
+    }
+
+    public void handleEvent(String event, String wholeMessage) {
+        if (event.equals("pusher:signin_success")) {
+            onSigninSuccess(GSON.fromJson(wholeMessage, PusherEvent.class));
+        }
+    }
+
+    private void attemptSignin() throws AuthenticationFailureException {
+        if (!signinRequested || userId != null) {
+            return;
+        }
+
+        if (connection.getState() != ConnectionState.CONNECTED) {
+            // Signin will be attempted when the connection is connected
+            return;
+        }
+
+        AuthenticationResponse authenticationResponse = getAuthenticationResponse();
+        connection.sendMessage(authenticationResponseToSigninMessage(authenticationResponse));
+    }
+
+    private static String authenticationResponseToSigninMessage(AuthenticationResponse authenticationResponse) {
+        return GSON.toJson(new SigninMessage(
+            authenticationResponse.getAuth(),
+            authenticationResponse.getUserData()
+        ));
+    }
+
+    private AuthenticationResponse getAuthenticationResponse() throws AuthenticationFailureException {
+        String response = userAuthenticator.authenticate(connection.getSocketId());
+        try {
+            AuthenticationResponse authenticationResponse = GSON.fromJson(response, AuthenticationResponse.class);
+            if (authenticationResponse.getAuth() == null && authenticationResponse.getUserData() == null) {
+                throw new AuthenticationFailureException("Didn't receive all the fields expected from the UserAuthenticator. Expected auth and user_data");
+            }
+            return authenticationResponse;
+        } catch (JsonSyntaxException e) {
+            throw new AuthenticationFailureException("Unable to parse response from AuthenticationResponse");
+        }
+    }
+
+    private void onSigninSuccess(PusherEvent event) {
+        try {
+            String userData = (String) GSON.fromJson(event.getData(), Map.class).get("user_data");
+            userId = (String) GSON.fromJson(userData, Map.class).get("id");
+        } catch (Exception e) {
+            log.severe("Failed parsing user data after signin");
+            return;
+        }
+
+        if (userId == null) {
+            log.severe("User data doesn't contain an id");
+            return;
+        }
+        channelManager.subscribeTo(serverToUserChannel, null);
+    }
+
+    private void disconnect() {
+        channelManager.unsubscribeFrom(serverToUserChannel.getName());
+        userId = null;
+    }
+
+    @Override
+    public String userId() {
+        return userId;
+    }
+
+    @Override
+    public void bind(String eventName, SubscriptionEventListener listener) {
+        serverToUserChannel.bind(eventName, listener);
+    }
+
+    @Override
+    public void bindGlobal(SubscriptionEventListener listener) {
+        serverToUserChannel.bindGlobal(listener);
+    }
+
+    @Override
+    public void unbind(String eventName, SubscriptionEventListener listener) {
+        serverToUserChannel.unbind(eventName, listener);
+    }
+
+    @Override
+    public void unbindGlobal(SubscriptionEventListener listener) {
+        serverToUserChannel.unbindGlobal(listener);
+    }
+}

--- a/src/main/java/com/pusher/client/user/impl/ServerToUserChannel.java
+++ b/src/main/java/com/pusher/client/user/impl/ServerToUserChannel.java
@@ -1,0 +1,24 @@
+package com.pusher.client.user.impl;
+
+import com.pusher.client.channel.impl.BaseChannel;
+import com.pusher.client.user.User;
+import com.pusher.client.util.Factory;
+
+class ServerToUserChannel extends BaseChannel {
+    private User user;
+
+    public ServerToUserChannel(User user, Factory factory) {
+        super(factory);
+
+        this.user = user;
+    }
+
+    @Override
+    public String getName() {
+        String userId = user.userId();
+        if (userId == null) {
+            throw new IllegalStateException("User id is null in ServerToUserChannel");
+        }
+            return "#server-to-user-" + user.userId();
+    }
+}

--- a/src/main/java/com/pusher/client/user/impl/message/AuthenticationResponse.java
+++ b/src/main/java/com/pusher/client/user/impl/message/AuthenticationResponse.java
@@ -1,0 +1,19 @@
+package com.pusher.client.connection.impl.message;
+
+import com.google.gson.annotations.SerializedName;
+
+public class AuthenticationResponse {
+    private String auth;
+
+    // we want to keep this as a String until needed because we send this back on requests
+    @SerializedName("user_data")
+    private String userData;
+
+    public String getAuth() {
+        return auth;
+    }
+
+    public String getUserData() {
+        return userData;
+    }
+}

--- a/src/main/java/com/pusher/client/user/impl/message/AuthenticationResponse.java
+++ b/src/main/java/com/pusher/client/user/impl/message/AuthenticationResponse.java
@@ -5,7 +5,6 @@ import com.google.gson.annotations.SerializedName;
 public class AuthenticationResponse {
     private String auth;
 
-    // we want to keep this as a String until needed because we send this back on requests
     @SerializedName("user_data")
     private String userData;
 

--- a/src/main/java/com/pusher/client/user/impl/message/SigninMessage.java
+++ b/src/main/java/com/pusher/client/user/impl/message/SigninMessage.java
@@ -1,0 +1,14 @@
+package com.pusher.client.connection.impl.message;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class SigninMessage {
+    private String event = "pusher:signin";
+    private Map<String, String> data = new HashMap<>();
+
+    public SigninMessage(String auth, String userData) {
+        data.put("auth", auth);
+        data.put("user_data", userData);
+    }
+}

--- a/src/test/java/com/pusher/client/EndToEndTest.java
+++ b/src/test/java/com/pusher/client/EndToEndTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import java.net.Proxy;
 import java.net.URI;
+import java.util.function.BiConsumer;
 
 import org.junit.After;
 import org.junit.Before;
@@ -60,7 +61,7 @@ public class EndToEndTest {
         pusherOptions = new PusherOptions().setChannelAuthorizer(mockChannelAuthorizer).setUseTLS(false);
 
         connection = new WebSocketConnection(pusherOptions.buildUrl(API_KEY), ACTIVITY_TIMEOUT, PONG_TIMEOUT, pusherOptions.getMaxReconnectionAttempts(),
-                pusherOptions.getMaxReconnectGapInSeconds(), proxy, factory);
+                 pusherOptions.getMaxReconnectGapInSeconds(), proxy, (event, wholeMessage) -> {}, factory);
 
         doAnswer(new Answer() {
             @Override
@@ -84,7 +85,7 @@ public class EndToEndTest {
                     }
                 });
 
-        when(factory.getConnection(API_KEY, pusherOptions)).thenReturn(connection);
+        when(factory.getConnection(eq(API_KEY), eq(pusherOptions), any(BiConsumer.class))).thenReturn(connection);
 
         when(factory.getChannelManager()).thenAnswer(new Answer<ChannelManager>() {
             @Override

--- a/src/test/java/com/pusher/client/channel/impl/ChannelImplTest.java
+++ b/src/test/java/com/pusher/client/channel/impl/ChannelImplTest.java
@@ -223,19 +223,6 @@ public class ChannelImplTest {
         verify(mockListener).onSubscriptionSucceeded(getChannelName());
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testBindWhenInUnsubscribedStateThrowsException() {
-        channel.updateState(ChannelState.UNSUBSCRIBED);
-        channel.bind(EVENT_NAME, mockListener);
-    }
-
-    @Test(expected = IllegalStateException.class)
-    public void testUnbindWhenInUnsubscribedStateThrowsException() {
-        channel.bind(EVENT_NAME, mockListener);
-        channel.updateState(ChannelState.UNSUBSCRIBED);
-        channel.unbind(EVENT_NAME, mockListener);
-    }
-
     /* end of tests */
 
     /**

--- a/src/test/java/com/pusher/client/user/impl/InternalUserTest.java
+++ b/src/test/java/com/pusher/client/user/impl/InternalUserTest.java
@@ -1,0 +1,98 @@
+package com.pusher.client.user.impl;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+import com.pusher.client.UserAuthenticator;
+import com.pusher.client.AuthenticationFailureException;
+import com.pusher.client.channel.SubscriptionEventListener;
+import com.pusher.client.channel.impl.ChannelManager;
+import com.pusher.client.connection.impl.InternalConnection;
+import com.pusher.client.connection.ConnectionState;
+import com.pusher.client.util.Factory;
+
+@RunWith(MockitoJUnitRunner.class)
+public class InternalUserTest {
+    private static final String socketId = "123";
+    private static final String authenticationResponse = "{\"auth\": \"123:456\", \"user_data\":\"{\\\"id\\\": \\\"someid\\\"}\"}";
+    private static final String authenticationResponseMalformed = "{}";
+    private static final String signinSuccessEvent = "{\"event\": \"pusher:signin_success\", \"data\": \"{\\\"user_data\\\": \\\"{\\\\\\\"id\\\\\\\":\\\\\\\"1\\\\\\\"}\\\"}\"}";
+    private static final String signinSuccessEventMissingId = "{\"event\": \"pusher:signin_success\", \"data\": \"{\\\"user_data\\\": \\\"{}\\\"}\"}";
+    private static final String signinSuccessEventMalformed = "{\"event\": \"pusher:signin_success\", \"data\": \"{}\"}";
+
+    private InternalUser user;
+    private @Mock UserAuthenticator mockUserAuthenticator;
+    private @Mock InternalConnection mockConnection;
+    private @Mock ChannelManager mockChannelManager;
+    private @Mock Factory mockFactory;
+    private @Mock SubscriptionEventListener mockEventListener;
+
+    @Before
+    public void setUp() {
+        when(mockConnection.getSocketId()).thenReturn(socketId);
+        when(mockFactory.getChannelManager()).thenReturn(mockChannelManager);
+        user = new InternalUser(mockConnection, mockUserAuthenticator, mockFactory);
+    }
+
+    @Test
+    public void testSigninWhenNotConnected() {
+        when(mockConnection.getState()).thenReturn(ConnectionState.DISCONNECTED);
+        user.signin();
+        verify(mockUserAuthenticator, never()).authenticate(any(String.class));
+        verify(mockConnection, never()).sendMessage(any(String.class));
+    }
+
+    @Test
+    public void testSigninWhenConnected() {
+        when(mockConnection.getState()).thenReturn(ConnectionState.CONNECTED);
+        when(mockUserAuthenticator.authenticate(socketId)).thenReturn(authenticationResponse);
+        user.signin();
+        verify(mockConnection).sendMessage(any(String.class));
+    }
+
+    @Test(expected = AuthenticationFailureException.class)
+    public void testSigninMalformedResponse() {
+        when(mockConnection.getState()).thenReturn(ConnectionState.CONNECTED);
+        when(mockUserAuthenticator.authenticate(socketId)).thenReturn(authenticationResponseMalformed);
+        user.signin();
+    }
+
+    @Test
+    public void testHandleEventSigninSuccessEvent() {
+        user.handleEvent("pusher:signin_success", signinSuccessEvent);
+        assertEquals(user.userId(), "1");
+        verify(mockChannelManager).subscribeTo(any(ServerToUserChannel.class), eq(null));
+    }
+
+    @Test
+    public void testHandleEventSigninSuccessEventMissingId() {
+        user.handleEvent("pusher:signin_success", signinSuccessEventMissingId);
+        assertNull(user.userId());
+        verify(mockChannelManager, never()).subscribeTo(any(ServerToUserChannel.class), eq(null));
+    }
+
+    @Test
+    public void testHandleEventSigninSuccessEventMalformed() {
+        user.handleEvent("pusher:signin_success", signinSuccessEventMalformed);
+        assertNull(user.userId());
+        verify(mockChannelManager, never()).subscribeTo(any(ServerToUserChannel.class), eq(null));
+    }
+
+    @Test
+    public void testSigninWhenSignedIn() {
+        when(mockConnection.getState()).thenReturn(ConnectionState.CONNECTED);
+        user.handleEvent("pusher:signin_success", signinSuccessEvent);
+        assertEquals(user.userId(), "1");
+        user.signin();
+        verify(mockUserAuthenticator, never()).authenticate(any(String.class));
+        verify(mockConnection, never()).sendMessage(any(String.class));
+    }
+}


### PR DESCRIPTION
### Description of the pull request

Add support for user signin and server to user messages.

Significant changes are:
* New User and InternalUser interface and class are introduced. These contain the main logic
* Channel implementation code was moved into an abstract BaseChannel, so that it could be reused for the ServerToUserChannel
* Event handling code was moved out of the connection that now takes in a eventHandler function. There's also a change in behaviour there that all events are passed to this event handler.

#### Why is the change necessary?

Rolling out support for the new user features to more SDKs.

----

CC @pusher/mobile 
