### PR TITLE
Allow disconnect to be called unless it's already disconnected or disconnecting

### DIFF
--- a/src/main/java/com/pusher/client/Pusher.java
+++ b/src/main/java/com/pusher/client/Pusher.java
@@ -196,7 +196,7 @@ public class Pusher implements Client {
      * </p>
      */
     public void disconnect() {
-        if (connection.getState() == ConnectionState.CONNECTED) {
+        if (connection.getState() != ConnectionState.DISCONNECTING && connection.getState() != ConnectionState.DISCONNECTED) {
             connection.disconnect();
         }
     }

--- a/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
+++ b/src/main/java/com/pusher/client/connection/websocket/WebSocketConnection.java
@@ -99,7 +99,7 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
         factory.queueOnEventThread(new Runnable() {
             @Override
             public void run() {
-                if (state == ConnectionState.CONNECTED) {
+                if (state != ConnectionState.DISCONNECTING && state != ConnectionState.DISCONNECTED) {
                     updateState(ConnectionState.DISCONNECTING);
                     underlyingConnection.close();
                 }
@@ -294,8 +294,10 @@ public class WebSocketConnection implements InternalConnection, WebSocketListene
         factory.getTimers().schedule(new Runnable() {
             @Override
             public void run() {
-                underlyingConnection.removeWebSocketListener();
-                tryConnecting();
+                if (state == ConnectionState.RECONNECTING) {
+                    underlyingConnection.removeWebSocketListener();
+                    tryConnecting();
+                }
             }
         }, reconnectInterval, TimeUnit.SECONDS);
     }

--- a/src/test/java/com/pusher/client/PusherTest.java
+++ b/src/test/java/com/pusher/client/PusherTest.java
@@ -119,14 +119,6 @@ public class PusherTest {
     }
 
     @Test
-    public void testDisconnectCallDoesNothingIfStateIsConnecting() {
-        when(mockConnection.getState()).thenReturn(ConnectionState.CONNECTING);
-
-        pusher.disconnect();
-        verify(mockConnection, never()).disconnect();
-    }
-
-    @Test
     public void testDisconnectCallDoesNothingIfStateIsDisconnecting() {
         when(mockConnection.getState()).thenReturn(ConnectionState.DISCONNECTING);
 

--- a/src/test/java/com/pusher/client/connection/websocket/WebSocketConnectionTest.java
+++ b/src/test/java/com/pusher/client/connection/websocket/WebSocketConnectionTest.java
@@ -274,15 +274,6 @@ public class WebSocketConnectionTest {
         verify(mockEventListener, times(0)).onConnectionStateChange(any(ConnectionStateChange.class));
     }
 
-    @Test
-    public void testDisconnectInConnectingStateIsIgnored() {
-        connection.connect();
-
-        connection.disconnect();
-
-        verify(mockUnderlyingConnection, times(0)).close();
-        verify(mockEventListener, times(1)).onConnectionStateChange(any(ConnectionStateChange.class));
-    }
 
     @Test
     public void testDisconnectInDisconnectingStateIsIgnored() {


### PR DESCRIPTION
### Description of the pull request

Allow `disconnect` to be called in more states

#### Why is the change necessary?

Fixes #189 

----

CC @pusher/mobile 
