### PR TITLE
Update readme for adding deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ The pusher-java-client is available in Maven Central.
 
 ```groovy
 dependencies {
-  compile 'com.pusher:pusher-java-client:2.4.2'
+  implementation 'com.pusher:pusher-java-client:2.4.2'
 }
 ```
 
@@ -618,7 +618,7 @@ project(':pusher-websocket-java').projectDir = new File('<PATH_TO_THIS_PROJECT>/
 
 ```
 dependencies {
-    compile project(':pusher-websocket-java')
+    implementation project(':pusher-websocket-java')
 }
 ```
 


### PR DESCRIPTION
### Description of the pull request

Change Gradle's `compile` to `implementation`.

#### Why is the change necessary?

compile has been disabled in Gradle 7: https://docs.gradle.org/current/userguide/declaring_dependencies.html#sub:project_dependencies
https://tomgregory.com/gradle-implementation-vs-compile-dependencies/
