### PR TITLE
Add proguard file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# pusher-websocket-java changelog
+# Changelog
+
+## 2.4.3
+
+- [FIXED] Fix issue with json serialization when using proguard
 
 ### Version 2.4.2 - 23th Sep 2022
 * Fixes a crash when an event comes in without and escaped data json member.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The pusher-java-client is available in Maven Central.
     <dependency>
       <groupId>com.pusher</groupId>
       <artifactId>pusher-java-client</artifactId>
-      <version>2.4.2</version>
+      <version>2.4.3</version>
     </dependency>
 </dependencies>
 ```
@@ -83,7 +83,7 @@ The pusher-java-client is available in Maven Central.
 
 ```groovy
 dependencies {
-  implementation 'com.pusher:pusher-java-client:2.4.2'
+  implementation 'com.pusher:pusher-java-client:2.4.3'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ def getProperty = { property ->
 }
 
 group = "com.pusher"
-version = "2.4.2"
+version = "2.4.3"
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 

--- a/src/main/resources/META-INF/proguard/pusher.pro
+++ b/src/main/resources/META-INF/proguard/pusher.pro
@@ -1,0 +1,1 @@
+-keep class com.pusher.client.** { *; }


### PR DESCRIPTION
## Description of the pull request

Add a proguard setting file excluding pusher.client classes from minifying.

#### Why is the change necessary?

Workaround for https://github.com/pusher/pusher-websocket-java/issues/333

## CHANGELOG

- [FIXED] Fix issue with json serialization when using proguard
