### PR TITLE
Android versions in readme supported platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Pusher Channels client library for Java targeting **Android** and general Java.
 
 ## Supported platforms
 
-* Java SE - supports versions 8, 9, 10 and 11.
+* Java SE - supports versions 8, 11 and 17
 * Oracle JDK
 * OpenJDK
-* Android
+* Android 7 and above. 5 and 6 will require [desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring).
 
 ## TOC
 


### PR DESCRIPTION
### Description of the pull request

Mention specific Android versions in the supported platforms section. Also cleanup Java versions.

#### Why is the change necessary?

Previously we didn't specify Android versions, but Android 5/6 will require additional steps which I've linked to.

I've trimmed down the Java versions to just the LTS versions to keep the list short.