### PR TITLE
Narrower proguard rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2.4.4
+
+- [CHANGED] pusher.pro narrower proguard rules.
+
 ## 2.4.3
 
 - [FIXED] Fix issue with json serialization when using proguard

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The pusher-java-client is available in Maven Central.
     <dependency>
       <groupId>com.pusher</groupId>
       <artifactId>pusher-java-client</artifactId>
-      <version>2.4.3</version>
+      <version>2.4.4</version>
     </dependency>
 </dependencies>
 ```
@@ -83,7 +83,7 @@ The pusher-java-client is available in Maven Central.
 
 ```groovy
 dependencies {
-  implementation 'com.pusher:pusher-java-client:2.4.3'
+  implementation 'com.pusher:pusher-java-client:2.4.4'
 }
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ def getProperty = { property ->
 }
 
 group = "com.pusher"
-version = "2.4.3"
+version = "2.4.4"
 sourceCompatibility = "1.8"
 targetCompatibility = "1.8"
 

--- a/src/main/resources/META-INF/proguard/pusher.pro
+++ b/src/main/resources/META-INF/proguard/pusher.pro
@@ -1,1 +1,2 @@
--keep class com.pusher.client.** { *; }
+-keep class com.pusher.client.channel.impl.message.** { *; }
+-keep class com.pusher.client.user.impl.message.** { *; }


### PR DESCRIPTION
## What does this PR do?

Tighten the proguard rules to fewer classes.

`-keep class com.pusher.client.** { *; }` is too broad.

## CHANGELOG

- [CHANGED] pusher.pro narrower proguard rules.
