### PR TITLE
Use BuildConfig instead of reading version from properties file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-
 buildscript {
     repositories {
         mavenCentral()
@@ -16,6 +14,7 @@ plugins {
     id "maven-publish"
     id "org.ajoberstar.github-pages" version "1.7.2"
     id "signing"
+    id "com.github.gmazzo.buildconfig" version "3.1.0"
 }
 
 def getProperty = { property ->
@@ -56,10 +55,8 @@ dependencies {
 }
 
 
-processResources {
-    filter(ReplaceTokens, tokens: [
-            version: project.version
-    ])
+buildConfig {
+    buildConfigField("String", "APP_VERSION", provider { "\"${project.version}\"" })
 }
 
 

--- a/src/main/java/com/pusher/client/PusherOptions.java
+++ b/src/main/java/com/pusher/client/PusherOptions.java
@@ -1,18 +1,15 @@
 package com.pusher.client;
 
-import java.io.IOException;
-import java.io.InputStream;
+import com.pusher.pusher_websocket_java.BuildConfig;
+
 import java.net.Proxy;
-import java.util.Properties;
 
 /**
  * Configuration for a {@link com.pusher.client.Pusher} instance.
  */
 public class PusherOptions {
 
-    private static final String SRC_LIB_DEV_VERSION = "@version@";
-    private static final String LIB_DEV_VERSION = "0.0.0-dev";
-    public static final String LIB_VERSION = readVersionFromProperties();
+    public static final String LIB_VERSION = BuildConfig.APP_VERSION;
 
     private static final String URI_SUFFIX = "?client=java-client&protocol=5&version=" + LIB_VERSION;
     private static final String WS_SCHEME = "ws";
@@ -314,37 +311,5 @@ public class PusherOptions {
      */
     public int getMaxReconnectGapInSeconds() {
         return maxReconnectGapInSeconds;
-    }
-
-    private static String readVersionFromProperties() {
-        InputStream inStream = null;
-        try {
-            final Properties p = new Properties();
-            inStream = PusherOptions.class.getResourceAsStream("/pusher.properties");
-            p.load(inStream);
-            String version = (String) p.get("version");
-
-            // If the properties file contents indicates the version is being run
-            // from source then replace with a dev indicator. Otherwise the Pusher
-            // Socket API will reject the connection.
-            if (version.equals(SRC_LIB_DEV_VERSION)) {
-                version = LIB_DEV_VERSION;
-            }
-
-            if (version != null && version.length() > 0) {
-                return version;
-            }
-        } catch (final Exception e) {
-            // Fall back to fixed value
-        } finally {
-            try {
-                if (inStream != null) {
-                    inStream.close();
-                }
-            } catch (final IOException e) {
-                // Ignore problem closing stream
-            }
-        }
-        return "0.0.0";
     }
 }

--- a/src/main/resources/pusher.properties
+++ b/src/main/resources/pusher.properties
@@ -1,2 +1,0 @@
-# The version token is filtered by the build
-version=@version@


### PR DESCRIPTION
## What does this PR do?

Fixes #288

Use [com.github.gmazzo.buildconfig](https://github.com/gmazzo/gradle-buildconfig-plugin) Gradle plugin (a plugin that generates `BuildConfig` like the Gradle `android` plugin, but for non-Android Java projects) to generate `BuildConfig` with project version at build time, instead of reading from `pusher.properties` at runtime, which fails with `DiskReadViolation` when running on Android with [StrictMode](https://developer.android.com/reference/android/os/StrictMode) enabled.

## CHANGELOG

- [CHANGED] Use `BuildConfig` instead of reading version from properties file
