### PR TITLE
Fix PusherEvent user id wrong key. Change userId to user_id

### DIFF
--- a/src/main/java/com/pusher/client/channel/PusherEvent.java
+++ b/src/main/java/com/pusher/client/channel/PusherEvent.java
@@ -70,7 +70,7 @@ public class PusherEvent {
     public PusherEvent(String event, String channel, String userId, String data) {
         jsonObject.addProperty("event", event);
         jsonObject.addProperty("channel", channel);
-        jsonObject.addProperty("userId", userId);
+        jsonObject.addProperty("user_id", userId);
         jsonObject.addProperty("data", data);
     }
 


### PR DESCRIPTION
## What does this PR do?
PusherEvent user id will always null when user use constructor. Wrong key `userId`

[Description here]

## CHANGELOG

- [CHANGED] Fix PusherEvent user id wrong key. Change constructor json key `userId` to `user_id`
