### PR TITLE
Allow custom SSL socket factory for BaseHttpAuthClient

### DIFF
--- a/src/main/java/com/pusher/client/util/BaseHttpAuthClient.java
+++ b/src/main/java/com/pusher/client/util/BaseHttpAuthClient.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Base class for {@link com.pusher.client.util.HttpChannelAuthorizer} and {@link com.pusher.client.util.HttpUserAuthenticator}
@@ -22,6 +23,7 @@ abstract class BaseHttpAuthClient {
     private final URL endPoint;
     private Map<String, String> mHeaders = new HashMap<>();
     protected ConnectionFactory mConnectionFactory;
+    protected SSLSocketFactory mSslSocketFactory = null;
 
     /**
      * Creates a new auth client.
@@ -62,6 +64,15 @@ abstract class BaseHttpAuthClient {
     }
 
     /**
+     * Set the SSL socket factory that is used for the connection. This allows to
+     * configure custom certificate handling (self-signed certificates, mutual TLS, ...)
+     * @param sslSocketFactory The SSL socket factory to use
+     */
+    public void setSslSocketFactory(final SSLSocketFactory sslSocketFactory) {
+        mSslSocketFactory = sslSocketFactory;
+    }
+
+    /**
      * Identifies if the HTTP request will be sent over HTTPS.
      *
      * @return true if the endpoint protocol is 'https'
@@ -92,6 +103,11 @@ abstract class BaseHttpAuthClient {
             HttpURLConnection connection;
             if (isSSL()) {
                 connection = (HttpsURLConnection) endPoint.openConnection();
+
+                if(mSslSocketFactory != null) {
+                    ((HttpsURLConnection) connection)
+                            .setSSLSocketFactory(mSslSocketFactory);
+                }
             } else {
                 connection = (HttpURLConnection) endPoint.openConnection();
             }


### PR DESCRIPTION
## What does this PR do?

This PR allows developers to set a custom SSL socket factory for the `BaseHttpAuthClient` and therefor enabling scenarios where mutual TLS is used for authentication. This is useful when using `HttpChannelAuthorizer` or `HttpUserAuthenticator` with an endpoint that is protected in such a way.

## CHANGELOG

- [CHANGED]  Added method `setSslSocketFactory` to `BaseHttpAuthClient`
